### PR TITLE
`LessonComplete` uses new completion count method.

### DIFF
--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -4,7 +4,9 @@ import {
     storeWagtailPage,
     getWagtailPageFromStore,
     getManifestFromStore,
-    storeManifest
+    storeManifest,
+    getLessonById,
+    getCourseById,
 } from "ReduxImpl/Store";
 
 async function token_authed_fetch(url) {
@@ -14,8 +16,8 @@ async function token_authed_fetch(url) {
         mode: "cors",
         headers: {
             "Content-Type": "text/json",
-            Authorization: `JWT ${token}`
-        }
+            Authorization: `JWT ${token}`,
+        },
     });
 
     if (!response.ok) {
@@ -40,7 +42,7 @@ export async function fetchPage(path) {
     return pageMetadata;
 }
 
-export const fetchImage = async path => {
+export const fetchImage = async (path) => {
     return new Promise((resolve, reject) => {
         const image = new Image();
         // Workbox only caches crossorigin images.
@@ -62,7 +64,7 @@ export const getOrFetchManifest = async () => {
     return manifest;
 };
 
-export const getOrFetchWagtailPage = async path => {
+export const getOrFetchWagtailPage = async (path) => {
     const pathPieces = path.split("/");
     const secondToLastPiece = pathPieces[pathPieces.length - 2];
     const pageId = Number(secondToLastPiece);
@@ -75,4 +77,35 @@ export const getOrFetchWagtailPage = async path => {
     const wagtailPage = await fetchPage(path);
     storeWagtailPage(wagtailPage);
     return wagtailPage;
+};
+
+const _getOrFetchWagtailPageById = async (pageId) => {
+    const manifest = await getOrFetchManifest();
+    const pagePath = manifest.pages[pageId];
+    return getOrFetchWagtailPage(pagePath);
+};
+
+export const getACoursesLessons = async (courseId) => {
+    await _getOrFetchWagtailPageById(courseId);
+
+    const course = getCourseById(courseId);
+    const lessonIds = course.lessonIds;
+    const lessons = [];
+
+    for (const lessonId of lessonIds) {
+        await _getOrFetchWagtailPageById(lessonId);
+        const lesson = getLessonById(lessonId);
+        lessons.push(lesson);
+    }
+    return lessons;
+};
+
+export const getALessonsCourse = async (lessonId) => {
+    await _getOrFetchWagtailPageById(lessonId);
+
+    const lesson = getLessonById(lessonId);
+    const parentCourseId = lesson.parentId;
+    await _getOrFetchWagtailPageById(parentCourseId);
+    const parentCourse = getCourseById(parentCourseId);
+    return parentCourse;
 };

--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -5,8 +5,8 @@ import {
     getWagtailPageFromStore,
     getManifestFromStore,
     storeManifest,
-    getLessonById,
-    getCourseById,
+    getCourse,
+    getLesson,
 } from "ReduxImpl/Store";
 
 async function token_authed_fetch(url) {
@@ -85,27 +85,46 @@ const _getOrFetchWagtailPageById = async (pageId) => {
     return getOrFetchWagtailPage(pagePath);
 };
 
-export const getACoursesLessons = async (courseId) => {
+export const getCourseById = async (courseId) => {
     await _getOrFetchWagtailPageById(courseId);
+    // Until we can switch to a flatter data representation, this ensures the
+    // store has the course.
 
-    const course = getCourseById(courseId);
+    const course = getCourse(courseId);
+    if (!course) {
+        throw new Error(`Course ${courseId} doesn't exist.`);
+    }
+    return course;
+};
+
+export const getLessonById = async (lessonId) => {
+    await _getOrFetchWagtailPageById(lessonId);
+    // Until we can switch to a flatter data representation, this ensures the
+    // store has the lesson.
+
+    const lesson = getLesson(lessonId);
+    if (!lesson) {
+        throw new Error(`Lesson ${lessonId} doesn't exist.`);
+    }
+    return lesson;
+};
+
+export const getACoursesLessons = async (courseId) => {
+    const course = await getCourseById(courseId);
     const lessonIds = course.lessonIds;
     const lessons = [];
 
     for (const lessonId of lessonIds) {
-        await _getOrFetchWagtailPageById(lessonId);
-        const lesson = getLessonById(lessonId);
+        const lesson = await getLessonById(lessonId);
         lessons.push(lesson);
     }
+
     return lessons;
 };
 
 export const getALessonsCourse = async (lessonId) => {
-    await _getOrFetchWagtailPageById(lessonId);
-
-    const lesson = getLessonById(lessonId);
+    const lesson = await getLessonById(lessonId);
     const parentCourseId = lesson.parentId;
-    await _getOrFetchWagtailPageById(parentCourseId);
-    const parentCourse = getCourseById(parentCourseId);
+    const parentCourse = await getCourseById(parentCourseId);
     return parentCourse;
 };

--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -70,18 +70,12 @@ export const isBrowserSupported = () => {
     return store.getState().isBrowserSupported;
 };
 
-export const getCourseById = (courseId) => {
+export const getCourse = (courseId) => {
     const course = store.getState().courses[courseId];
-    if (!course) {
-        throw new Error(`Course ${courseId} doesn't exist.`);
-    }
     return course;
 };
 
-export const getLessonById = (lessonId) => {
+export const getLesson = (lessonId) => {
     const lesson = store.getState().lessons[lessonId];
-    if (!lesson) {
-        throw new Error(`Lesson ${lessonId} doesn't exist.`);
-    }
     return lesson;
 };

--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -81,27 +81,7 @@ export const getCourseById = (courseId) => {
 export const getLessonById = (lessonId) => {
     const lesson = store.getState().lessons[lessonId];
     if (!lesson) {
-        throw new Error(`Course ${lessonId} doesn't exist.`);
+        throw new Error(`Lesson ${lessonId} doesn't exist.`);
     }
     return lesson;
-};
-
-export const getACoursesLessons = (courseId) => {
-    const course = store.getState().courses[courseId];
-    if (!course) {
-        throw new Error(`Course ${courseId} doesn't exist.`);
-    }
-    const lessonIds = course.lessonIds;
-    const lessons = lessonIds.map(lessonId => getLessonById(lessonId));
-    return lessons;
-};
-
-export const getALessonsCourse = (lessonId) => {
-    const lesson = store.getState().lessons[lessonId];
-    if (!lesson) {
-        throw new Error(`Course ${lessonId} doesn't exist.`);
-    }
-    const parentCourseId = lesson.parentId;
-    const parentCourse = getCourseById(parentCourseId);
-    return parentCourse;
 };

--- a/src/riot/Lesson/LessonComplete.riot.html
+++ b/src/riot/Lesson/LessonComplete.riot.html
@@ -1,40 +1,64 @@
 <LessonComplete>
     <LessonFrame>
-        <div class="confetti background"></div>
-        <div class="report-card overlay"></div>
-        <div class="congratulations-container">
-            <template if="{!isCourseComplete()}">
-                <div>
-                    <h2 translate>Congratulations!</h2>
-                    <p>{ lessonCompleteMessage() }</p>
-                </div>
-                <button class="btn-primary" onclick="{goToCourseOverview}" translate>
-                    Next Lesson
-                </button>
-            </template>
-            <template if="{isCourseComplete()}">
-                <div>
-                    <h2 translate>Amazing work!</h2>
-                    <h3 translate>You've completed the course</h3>
-                    <p translate>
-                        You are eligible to receive a printed certificate for this course.
-                    </p>
-                </div>
-                <button class="btn-secondary" onclick="{goHome}" translate>Back to Courses</button>
-            </template>
-        </div>
+        <template if="{state.lessons.length}">
+            <div class="confetti background"></div>
+            <div class="report-card overlay"></div>
+            <div class="congratulations-container">
+                <template if="{!isCourseComplete()}">
+                    <div>
+                        <h2 translate>Congratulations!</h2>
+                        <p>{ lessonCompleteMessage() }</p>
+                    </div>
+                    <button class="btn-primary" onclick="{goToCourseOverview}" translate>
+                        Next Lesson
+                    </button>
+                </template>
+                <template if="{isCourseComplete()}">
+                    <div>
+                        <h2 translate>Amazing work!</h2>
+                        <h3 translate>You've completed the course</h3>
+                        <p translate>
+                            You are eligible to receive a printed certificate for this course.
+                        </p>
+                    </div>
+                    <button class="btn-secondary" onclick="{goHome}" translate>
+                        Back to Courses
+                    </button>
+                </template>
+            </div>
+        </template>
     </LessonFrame>
     <script>
         import LessonFrame from "RiotTags/Components/LessonFrame.riot.html";
         import { countComplete } from "Actions/completion";
+        import { getACoursesLessons } from "js/WagtailPagesAPI";
+        import { getNumberOfCompleteLessons } from "js/LearningStatistics";
 
         export default {
             components: {
                 lessonframe: LessonFrame,
             },
 
+            state: {
+                lessons: [],
+            },
+
+            onMounted() {
+                this.loadCompletedLessonsData();
+            },
+
+            async loadCompletedLessonsData() {
+                const lessons = await getACoursesLessons(this.props.course.id);
+                console.log(lessons);
+                const lessonSlugs = lessons.map((lesson) => lesson.slug);
+                this.update({ lessons: lessonSlugs });
+            },
+
             isCourseComplete() {
-                return countComplete(this.props.course.slug) === this.props.course.lessons_count;
+                return (
+                    getNumberOfCompleteLessons(this.props.course.slug, this.state.lessons) ===
+                    this.props.course.lessons_count
+                );
             },
 
             goToCourseOverview() {

--- a/src/riot/Lesson/LessonComplete.riot.html
+++ b/src/riot/Lesson/LessonComplete.riot.html
@@ -50,7 +50,7 @@
             async loadLessonsForIsCourseComplete() {
                 const lessons = await getACoursesLessons(this.props.course.id);
                 const lessonSlugs = lessons.map((lesson) => lesson.slug);
-                this.update({ lessons: lessonSlugs });
+                this.update({ lessonSlugs });
             },
 
             isCourseComplete() {

--- a/src/riot/Lesson/LessonComplete.riot.html
+++ b/src/riot/Lesson/LessonComplete.riot.html
@@ -1,6 +1,6 @@
 <LessonComplete>
     <LessonFrame>
-        <template if="{state.lessons.length}">
+        <template if="{state.lessonSlugs.length}">
             <div class="confetti background"></div>
             <div class="report-card overlay"></div>
             <div class="congratulations-container">
@@ -40,23 +40,22 @@
             },
 
             state: {
-                lessons: [],
+                lessonSlugs: [],
             },
 
             onMounted() {
-                this.loadCompletedLessonsData();
+                this.loadLessonsForIsCourseComplete();
             },
 
-            async loadCompletedLessonsData() {
+            async loadLessonsForIsCourseComplete() {
                 const lessons = await getACoursesLessons(this.props.course.id);
-                console.log(lessons);
                 const lessonSlugs = lessons.map((lesson) => lesson.slug);
                 this.update({ lessons: lessonSlugs });
             },
 
             isCourseComplete() {
                 return (
-                    getNumberOfCompleteLessons(this.props.course.slug, this.state.lessons) ===
+                    getNumberOfCompleteLessons(this.props.course.slug, this.state.lessonSlugs) ===
                     this.props.course.lessons_count
                 );
             },

--- a/src/riot/WagtailPages/HomePage.riot.html
+++ b/src/riot/WagtailPages/HomePage.riot.html
@@ -46,7 +46,6 @@
     </div>
 
     <script>
-        import { getOrFetchManifest, getOrFetchWagtailPage } from "js/WagtailPagesAPI";
         import ContinueLearningButton from "RiotTags/Components/ContinueLearningButton.riot.html";
         import Card from "RiotTags/Components/Card.riot.html";
 


### PR DESCRIPTION
@PeteCoward The code base uses the buggy `countComplete` in two places:
1. In `LessonComplete.riot.html`, `isCourseComplete`;
2. In `completion.js`, `isTheCourseComplete`.

This PR fixes 1.

### Implementation Details
This PR merges into `normalized-learning`, which takes first steps towards reducing the courseware's data footprint.

#50 addresses that `countComplete` is ignorant of which lessons and courses are live. #50 created `getNumberOfCompleteLessons`, which compares our completion data against a list of live lessons.