### PR TITLE
Display and cache images from available renditions

### DIFF
--- a/src/js/RenditionSelector.js
+++ b/src/js/RenditionSelector.js
@@ -3,15 +3,15 @@ import { getManifestFromStore } from "ReduxImpl/Store"
 
 const FILTER_SPEC = 'width-800|format-webp';
 
-export function imagePath(id) {
+export function getImagePath(id) {
     const images = getManifestFromStore().images;
-    return renditionUrl(images[id]);
+    return _getRenditionUrl(images[id]);
 }
 
-export function imageUrls(images) {
-    return Object.values(images).map(renditionUrl);
+export function getImageUrls(images) {
+    return Object.values(images).map(_getRenditionUrl);
 }
 
-function renditionUrl(renditions) {
+function _getRenditionUrl(renditions) {
     return `${BACKEND_BASE_URL}/media/${renditions[FILTER_SPEC]}`;
 }

--- a/src/js/RenditionSelector.js
+++ b/src/js/RenditionSelector.js
@@ -1,0 +1,17 @@
+import { BACKEND_BASE_URL } from "js/urls"
+import { getManifestFromStore } from "ReduxImpl/Store"
+
+const FILTER_SPEC = 'width-800|format-webp';
+
+export function imagePath(id) {
+    const images = getManifestFromStore().images;
+    return renditionUrl(images[id]);
+}
+
+export function imageUrls(images) {
+    return Object.values(images).map(renditionUrl);
+}
+
+function renditionUrl(renditions) {
+    return `${BACKEND_BASE_URL}/media/${renditions[FILTER_SPEC]}`;
+}

--- a/src/js/SiteDownloader.js
+++ b/src/js/SiteDownloader.js
@@ -2,6 +2,7 @@ import { fetchPage, fetchImage, getOrFetchManifest } from "js/WagtailPagesAPI";
 import { storeWagtailPage } from "ReduxImpl/Store";
 import { dispatchToastEvent } from "js/Events";
 import { leftDifference } from "js/SetMethods";
+import { imageUrls } from "js/RenditionSelector"
 
 const trimDomain = urlWithDomain => urlWithDomain.replace(/^.*\/\/[^\/]+/, "");
 
@@ -44,7 +45,7 @@ export class SiteDownloader {
         const manifest = await getOrFetchManifest();
 
         const manifestsPageUrls = new Set([manifest.home, ...Object.values(manifest.pages)]);
-        const manifestsMediaUrls = new Set(Object.values(manifest.images));
+        const manifestsMediaUrls = new Set(imageUrls(manifest.images));
 
         const cachedPageUrls = await getCachedUrlsAndDeleteCruft(
             this.PAGES_CACHE,

--- a/src/js/SiteDownloader.js
+++ b/src/js/SiteDownloader.js
@@ -2,7 +2,7 @@ import { fetchPage, fetchImage, getOrFetchManifest } from "js/WagtailPagesAPI";
 import { storeWagtailPage } from "ReduxImpl/Store";
 import { dispatchToastEvent } from "js/Events";
 import { leftDifference } from "js/SetMethods";
-import { imageUrls } from "js/RenditionSelector"
+import { getImageUrls } from "js/RenditionSelector"
 
 const trimDomain = urlWithDomain => urlWithDomain.replace(/^.*\/\/[^\/]+/, "");
 
@@ -45,7 +45,7 @@ export class SiteDownloader {
         const manifest = await getOrFetchManifest();
 
         const manifestsPageUrls = new Set([manifest.home, ...Object.values(manifest.pages)]);
-        const manifestsMediaUrls = new Set(imageUrls(manifest.images));
+        const manifestsMediaUrls = new Set(getImageUrls(manifest.images));
 
         const cachedPageUrls = await getCachedUrlsAndDeleteCruft(
             this.PAGES_CACHE,

--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -40,14 +40,14 @@ export async function fetchPage(path) {
     return pageMetadata;
 }
 
-export const fetchImage = async path => {
+export const fetchImage = async (url) => {
     return new Promise((resolve, reject) => {
         const image = new Image();
         // Workbox only caches crossorigin images.
         image.crossOrigin = "anonymous";
         image.onload = () => resolve(image.height);
         image.onerror = reject;
-        image.src = `${BACKEND_BASE_URL}${path}`;
+        image.src = url;
     });
 };
 

--- a/src/riot/Components/BaseCard.riot.html
+++ b/src/riot/Components/BaseCard.riot.html
@@ -1,0 +1,30 @@
+<basecard>
+    <h3 if={ props.card.header }>{ props.card.header }</h3>
+
+    <imagewrapper if={ props.card.image.id } 
+        id="{ props.card.image.id }" 
+        alt="{ props.card.image.alt }">
+    </imagewrapper>
+
+    <div class="richtext" />
+
+    <script>
+        import ImageWrapper from "RiotTags/Components/ImageWrapper.riot.html";
+        export default {
+            components: {
+                imagewrapper: ImageWrapper
+            },
+            setInnerHTML() {
+                this.$(".richtext").innerHTML = this.props.card.content;
+            },
+
+            onMounted() {
+                this.setInnerHTML();
+            },
+
+            onUpdated() {
+                this.setInnerHTML();
+            },
+        };
+    </script>
+</basecard>

--- a/src/riot/Components/BasicCard.riot.html
+++ b/src/riot/Components/BasicCard.riot.html
@@ -1,10 +1,10 @@
-<basecard>
-    <h3 if={ props.card.header }>{ props.card.header }</h3>
+<BasicCard>
+    <h3 if="{ props.card.header }">{ props.card.header }</h3>
 
-    <imagewrapper if={ props.card.image.id } 
+    <ImageWrapper if="{ props.card.image.id }" 
         id="{ props.card.image.id }" 
         alt="{ props.card.image.alt }">
-    </imagewrapper>
+    </ImageWrapper>
 
     <div class="richtext" />
 
@@ -27,4 +27,4 @@
             },
         };
     </script>
-</basecard>
+</BasicCard>

--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -1,0 +1,16 @@
+<imagewrapper>
+    <img alt="{ props.alt }" 
+        class="richtext-image"
+        crossorigin="anonymous"
+        src="{ getImagePath(props.id) }">
+    </div>
+
+    <script>
+        import { imagePath } from "js/RenditionSelector"
+        export default {
+            getImagePath(id) {
+                return imagePath(id);
+            },
+        };
+    </script>
+</imagewrapper>

--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -1,15 +1,15 @@
 <imagewrapper>
-    <img alt="{ props.alt }" 
+    <img alt="{ props.alt }"
         class="richtext-image"
         crossorigin="anonymous"
-        src="{ getImagePath(props.id) }">
-    </div>
+        src="{ imagePath(props.id) }">
+    </img>
 
     <script>
-        import { imagePath } from "js/RenditionSelector"
+        import { getImagePath } from "js/RenditionSelector"
         export default {
-            getImagePath(id) {
-                return imagePath(id);
+            imagePath(id) {
+                return getImagePath(id);
             },
         };
     </script>

--- a/src/riot/Components/Media.riot.html
+++ b/src/riot/Components/Media.riot.html
@@ -30,12 +30,12 @@
     </div>
 
     <script>
-        import { BACKEND_BASE_URL } from "../js/urls";
+        import { BACKEND_BASE_URL } from "js/urls";
         import {
             isItemCached,
             addToCache,
             deleteItemFromCache
-        } from "../js/cacheManager/cacheManager.js";
+        } from "js/cacheManager/cacheManager.js";
 
         export default {
             state: {

--- a/src/riot/Components/Raw.riot.html
+++ b/src/riot/Components/Raw.riot.html
@@ -1,8 +1,24 @@
 <raw>
     <script>
+        import * as riot from "riot";
+        import ImageWrapper from "RiotTags/Components/ImageWrapper.riot.html";
+
+        const mountImage = riot.component(ImageWrapper);
         export default {
             setInnerHTML() {
                 this.root.innerHTML = this.props.html;
+                this.$$("embed").forEach(m => {
+                    mountImage(
+                        m.insertAdjacentElement(
+                            "afterend",
+                            document.createElement("div")
+                        ),
+                        {
+                            id:m.getAttribute("id"),
+                            alt:m.getAttribute("alt"),
+                        }
+                    );
+                });
             },
 
             onMounted() {

--- a/src/riot/Components/Raw.riot.html
+++ b/src/riot/Components/Raw.riot.html
@@ -1,21 +1,21 @@
 <raw>
     <script>
-        import * as riot from "riot";
+        import { component } from "riot";
         import ImageWrapper from "RiotTags/Components/ImageWrapper.riot.html";
 
-        const mountImage = riot.component(ImageWrapper);
+        const mountImage = component(ImageWrapper);
         export default {
             setInnerHTML() {
                 this.root.innerHTML = this.props.html;
-                this.$$("embed").forEach(m => {
+                this.$$("embed").forEach(embed => {
                     mountImage(
-                        m.insertAdjacentElement(
+                        embed.insertAdjacentElement(
                             "afterend",
                             document.createElement("div")
                         ),
                         {
-                            id:m.getAttribute("id"),
-                            alt:m.getAttribute("alt"),
+                            id: embed.getAttribute("id"),
+                            alt: embed.getAttribute("alt"),
                         }
                     );
                 });

--- a/src/riot/Lesson/LessonContent.riot.html
+++ b/src/riot/Lesson/LessonContent.riot.html
@@ -5,6 +5,10 @@
                 if="{props.lessonContent.cards[state.cardIdx].tag === 'raw'}"
                 html="{props.lessonContent.cards[state.cardIdx].content}"
             />
+            <BaseCard
+                if="{props.lessonContent.cards[state.cardIdx].tag === 'base'}"
+                card="{props.lessonContent.cards[state.cardIdx]}"
+            />
             <Media
                 if="{props.lessonContent.cards[state.cardIdx].tag === 'media'}"
                 media="{props.lessonContent.cards[state.cardIdx]}"
@@ -47,7 +51,8 @@
     <script>
         import LessonModuleComplete from "RiotTags/Lesson/LessonModuleComplete.riot.html";
         import Raw from "RiotTags/Components/Raw.riot.html";
-        import Media from "RiotTags/Media.riot.html";
+        import Media from "RiotTags/Components/Media.riot.html";
+        import BaseCard from "RiotTags/Components/BaseCard.riot.html";
 
         import { getLessonCardIdx, getLessonModuleHash } from "js/Routing";
         import { setComplete } from "Actions/completion";
@@ -62,6 +67,7 @@
             components: {
                 lessonmodulecomplete: LessonModuleComplete,
                 media: Media,
+                basecard: BaseCard,
                 raw: Raw,
             },
 

--- a/src/riot/Lesson/LessonContent.riot.html
+++ b/src/riot/Lesson/LessonContent.riot.html
@@ -5,8 +5,8 @@
                 if="{props.lessonContent.cards[state.cardIdx].tag === 'raw'}"
                 html="{props.lessonContent.cards[state.cardIdx].content}"
             />
-            <BaseCard
-                if="{props.lessonContent.cards[state.cardIdx].tag === 'base'}"
+            <BasicCard
+                if="{props.lessonContent.cards[state.cardIdx].tag === 'basic'}"
                 card="{props.lessonContent.cards[state.cardIdx]}"
             />
             <Media
@@ -52,7 +52,7 @@
         import LessonModuleComplete from "RiotTags/Lesson/LessonModuleComplete.riot.html";
         import Raw from "RiotTags/Components/Raw.riot.html";
         import Media from "RiotTags/Components/Media.riot.html";
-        import BaseCard from "RiotTags/Components/BaseCard.riot.html";
+        import BasicCard from "RiotTags/Components/BasicCard.riot.html";
 
         import { getLessonCardIdx, getLessonModuleHash } from "js/Routing";
         import { setComplete } from "Actions/completion";
@@ -67,7 +67,7 @@
             components: {
                 lessonmodulecomplete: LessonModuleComplete,
                 media: Media,
-                basecard: BaseCard,
+                basiccard: BasicCard,
                 raw: Raw,
             },
 


### PR DESCRIPTION
- adds a very simplistic RenditionSelector component used by pre-caching and image display to choose the right rendition
- adds a BaseCard implementation to render new block type from https://github.com/catalpainternational/canoe-backend/pull/5
- adds an ImageWrapper tag to render an image using the RenditionSelector
- moves the Media tag into a better location
- updates the Raw tag to react to the raw `embed` elements by mounting an ImageWrapper

I think we can talk about being more intelligent in the RenditionSelector, and falling back if the rendition is not present.
Also the `riot.component` approach in the Raw tag is something which we could use in more places to make multiple tag mounting more modular ( @sandroroux this is what we tried and failed to do in App a while back I think )
