### PR TITLE
Card missing duration

### DIFF
--- a/src/riot/Components/Card.riot.html
+++ b/src/riot/Components/Card.riot.html
@@ -27,9 +27,8 @@
             durationMessage() {
                 // the number of minutes it will take to complete the objective, content, test, or lesson
                 return ngettext(
-                    "%1 min", 
-                    "%1 mins",
-                    this.props.duration,
+                    "%1 minute",
+                    "%1 minutes",
                     this.props.duration
                 );
             },

--- a/src/riot/WagtailPages/HomePage.riot.html
+++ b/src/riot/WagtailPages/HomePage.riot.html
@@ -88,6 +88,7 @@
             },
 
             continueLearningMessage() {
+                // displays the number of lessons a user has left to complete in a course
                 return ngettext(
                     "You only have %1 lesson left to finish %2.",
                     "You only have %1 lessons left to finish %2.",


### PR DESCRIPTION
Fixes https://github.com/catalpainternational/asteroid/issues/51

It appears that `ngettext` has a minimum number of characters that it will translate. "1 min" or "3 mins" is too short, but "1 minute" and "3 minutes" works.