### PR TITLE
Lighthouse suggested feedback

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,6 +139,8 @@ module.exports = (env) => {
                 short_name: projectConfiguration.SITE_SHORT_NAME,
                 description: projectConfiguration.SITE_DESCRIPTION,
                 background_color: projectConfiguration.BACKGROUND_COLOR,
+                theme_color: projectConfiguration.BACKGROUND_COLOR,
+                start_url: "/",
                 icons: [
                     {
                       src: projectConfiguration.FAVICON_PATH,
@@ -155,7 +157,7 @@ module.exports = (env) => {
                     },
                     {
                       src: projectConfiguration.FAVICON_PATH,
-                      sizes: [96],
+                      sizes: [512],
                       destination: path.join("icons", "android"),
                     }
                 ]


### PR DESCRIPTION
- add theme_color
- define start_url
- use a 512px icon

bumps up our score on lighthouse a little, the only slightly controvesrial thing might be using only a 512 icon. 
I'd like to look into excluding some things from the precaching so we can provide the recommended range of icon sizes without making everyone download them all.