### PR TITLE
Make the app look good on desktop

### DIFF
--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -162,7 +162,7 @@
 
     overflow-y: auto;
     min-height: calc(100vh - (#{$bottom-menu-height-no-footer} * 6));
-    max-width: 40em;
+    max-width: $tablet;
 
     background-color: $white;
 }

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -165,6 +165,10 @@
     max-width: $tablet;
 
     background-color: $white;
+
+    @media only screen and (min-width: $tablet-plus) {
+        margin: auto;
+    }
 }
 
 .notification-card {

--- a/src/scss/_home.scss
+++ b/src/scss/_home.scss
@@ -39,9 +39,11 @@ h5.section-title:after {
 }
 
 HomePage .header {
-    margin-top: 0;
     padding: 0px 30px 0 45px;
     height: 181px;
+    margin-top: -65px;
+    padding-top: 65px;
+    background-color: $blue-1;
     
     h3 { 
         color: white;
@@ -58,6 +60,8 @@ HomePage .header {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        max-width: $tablet;
+        margin: auto;
     }
 }
 

--- a/src/scss/_home.scss
+++ b/src/scss/_home.scss
@@ -90,6 +90,11 @@ HomePage .left-block {
 }
 
 HomePage div.content-wrapper {	
-    margin-left: 0;	
-    margin-right: 0;	
+    border-radius: 30px 30px 0 0;
+
+    @media only screen and (max-width: $tablet) {
+        margin-left: 0;	
+        margin-right: 0;
+        border-radius: 0px;
+    }
 }

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -245,7 +245,7 @@ LessonFrame {
 
         overflow-y: auto;
         height: calc(100vh - (#{$bottom-menu-height-no-footer} * 6));
-        max-width: 40em;
+        max-width: $tablet;
 
         background-color: $white;
     }

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -248,6 +248,10 @@ LessonFrame {
         max-width: $tablet;
 
         background-color: $white;
+
+        @media only screen and (min-width: $tablet-plus) {
+            margin: auto;
+        }
     }
 }
 

--- a/src/scss/_notifications.scss
+++ b/src/scss/_notifications.scss
@@ -14,6 +14,8 @@
     .notifications-header {
         @include screen-banner-styles;
         background-color: $notifications-banner-orange;
+        margin-top: -65px;
+        padding-top: 65px;
     }
 
     .left-block {

--- a/src/scss/_profile.scss
+++ b/src/scss/_profile.scss
@@ -30,6 +30,8 @@
 .profile-header {
     @include screen-banner-styles;
     background-color: $profile-banner-green;
+    margin-top: -65px;
+    padding-top: 65px;
 }
 
 Profile .background-gray-2 {

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -7,8 +7,11 @@
     .content-wrapper {
         flex-direction: column;
         display: flex;
-        margin-left: 0;	
-        margin-right: 0;
+
+        @media only screen and (max-width: $tablet-plus) {
+            margin-left: 0;	
+            margin-right: 0;
+        }
     }
 
     button {

--- a/src/scss/_top_menu.scss
+++ b/src/scss/_top_menu.scss
@@ -7,6 +7,11 @@ header {
     padding-left: 15px;
     display: flex;
 
+    @media only screen and (min-width: $tablet-plus) {
+        max-width: $tablet;
+        margin: auto;
+    }
+
     a.site-logo, a.site-logo.white {
         position: absolute;
         margin: auto;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -48,3 +48,4 @@ $border: 1px solid $gray-8;
 // Breakpoints
 $sm-phone: 374px;
 $tablet: 600px;
+$tablet-plus: 680px;

--- a/src/scss/olgeta.scss
+++ b/src/scss/olgeta.scss
@@ -35,7 +35,7 @@ div.content-wrapper {
     max-width: $tablet;
     margin: auto;
 
-    @media only screen and (max-width: $tablet) {
+    @media only screen and (max-width: $tablet-plus) {
         margin: auto 10px;
     }
 }

--- a/src/scss/olgeta.scss
+++ b/src/scss/olgeta.scss
@@ -32,8 +32,12 @@ div.content-wrapper {
     padding-right: 30px;
     padding-left: 30px;
     background-color: $tan;
-    max-width: 40em;
-    margin: auto 10px;
+    max-width: $tablet;
+    margin: auto;
+
+    @media only screen and (max-width: $tablet) {
+        margin: auto 10px;
+    }
 }
 
 .notifications,


### PR DESCRIPTION
Fixes https://github.com/catalpainternational/asteroid/issues/71

- Center the main content-wrapper on each page (home, profile, settings, cards, etc)
- Limit the width of the top banner and menu so that the buttons are centered above the content
- Make sure the background colors of the header/top banner spreads accordingly
   - that's the reason behind the multiple `margin-top: -65px; padding-top: 65px;`.