### PR TITLE
Quickfix for tetum translation oddness

### DIFF
--- a/modules/Translation.js
+++ b/modules/Translation.js
@@ -4,6 +4,13 @@ import { store } from "ReduxImpl/Store";
 
 var i18n = gettext_js();
 
+// gettext.js seems to behave wrong when passed a nplurals 1 translation set
+// A temporary fix pending further investigation is to
+// iterate over all array value tranlsations adding a fake n=2 message
+Object.values(tetumTranslations).filter(Array.isArray).forEach((arr) => {
+    arr.push(arr[0]);
+});
+
 i18n.loadJSON(tetumTranslations, "messages");
 
 export function gettext(msgid /* , extra */) {


### PR DESCRIPTION
So the gettext library we are using has broken behaviour. This is a quick fix while I look into it further.

options:
1. use a different library
2. code it ourselves
3. keep this hacky fix
4. Actually get transifex to believe tetum is nplurals=2
5. investigate if it is po2json causing our problems