### PR TITLE
choose a more conservative token cookie expiry date

### DIFF
--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -9,7 +9,8 @@ const USER_GROUPS_STORAGE_KEY = "userGroups";
 const setCookie = (name, value, keyOnlyAttributes = [], attributes = {}) => {
     // sets name=value cookie
     // sets keyOnlyAttributes provided eg ['secure', 'samesite']
-    // sets value attributes provided eg {expires:'Fri, 31 Dec 9999 23:59:59 GMT'}
+    // sets value attributes provided eg {expires: 'Tue 19 Jan 2038 03:14:07 GMT'}
+    // and potentially does vastly different things, because it does not escape inputs.
     document.cookie = Object.entries(attributes).reduce(
         (cookieString, keyValue) => `${cookieString};${keyValue[0]}=${keyValue[1]}`,
         keyOnlyAttributes.reduce(
@@ -68,7 +69,7 @@ export const login = async usernameAndPassword => {
     // Browsers refuse to set secure cookies from non https locations
     setCookie(JWT_TOKEN_STORAGE_KEY, token,
         window.location.protocol === "https:" ? ["secure"] : [],
-        {expires: "Fri, 31 Dec 9999 23:59:59 GMT", samesite: "strict"}
+        {expires: "Tue 19 Jan 2038 03:14:07 GMT", samesite: "strict"}
     );
     localStorage.setItem(USERNAME_STORAGE_KEY, username);
     localStorage.setItem(USER_ID_STORAGE_KEY, userId);


### PR DESCRIPTION
Fixes catalpainternational/asteroid#73

This fixes a mistake (*egregious expiry*) introduced with #71, which was meant to address issue catalpainternational/asteroid#68 which came about because there was *no expiry*.

Surely this time we'll get it right. Also, let's all remember to test against 32bit. There's 32bit (armeabi-v7) Android mobile phones out there.