### PR TITLE
Back button grabs page in correct language

### DIFF
--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -3,6 +3,7 @@ import {
     getOrFetchWagtailPage,
     getOrFetchManifest,
     getHomePage,
+    getWagtailPage,
 } from "js/WagtailPagesAPI.js";
 
 const IS_SETTINGS_NOTIFICATIONS_OR_PROFILE = /#([A-Za-z]+)/;
@@ -21,8 +22,6 @@ const getPreviewPageUrl = (queryString) => {
 };
 
 export const getPage = async () => {
-    const manifest = await getOrFetchManifest();
-
     const wagtailPageMatch = window.location.hash.match(IS_WAGTAIL_PAGE);
     const wagtailPreviewMatch = window.location.search.match(IS_PAGE_PREVIEW);
     const appPageMatch = window.location.hash.match(IS_SETTINGS_NOTIFICATIONS_OR_PROFILE);
@@ -32,8 +31,7 @@ export const getPage = async () => {
 
     if (wagtailPageMatch) {
         const pageId = wagtailPageMatch[1];
-        const pageUrl = manifest.pages[pageId];
-        page = await getOrFetchWagtailPage(pageUrl);
+        page = await getWagtailPage(pageId);
     } else if (wagtailPreviewMatch) {
         const queryString = wagtailPreviewMatch[1];
         pageUrl = getPreviewPageUrl(queryString);
@@ -49,6 +47,7 @@ export const getPage = async () => {
         page = await getHomePage();
     }
 
+    console.log("Got page.");
     return page;
 };
 

--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -36,19 +36,22 @@ const routeToTranslation = (translationPageId) => {
 export const getWagtailPageOrRouteToTranslation = async (pageId) => {
     const manifest = await getOrFetchManifest();
     const pageUrl = manifest.pages[pageId];
-    let page = await getOrFetchWagtailPage(pageUrl);
+    const page = await getOrFetchWagtailPage(pageUrl);
 
     const currentLanguage = getLanguage();
     const translationInfo = page.data.translations;
 
-    // If Canoe ever adds three or more languages, the rest of the function must
-    // change.
-
-    const translationLanguage = Object.keys(translationInfo)[0];
-    if (currentLanguage !== translationLanguage) {
+    const translationsLangCodes = Objects.keys(translationInfo);
+    // The default case:
+    // The page you're viewing is in the current language, which means the
+    // page's translations should lack the current language. Return the page.
+    if (!translationsLangCodes.includes(currentLanguage)) {
         return page;
     }
-    const translationPageId = translationInfo[translationLanguage];
+
+    // Otherwise, we want the page in the current language. Grab it from the
+    // incorrect page's translations.
+    const translationPageId = translationInfo[currentLanguage];
     routeToTranslation(translationPageId);
     return page;
 };
@@ -79,7 +82,6 @@ export const getPage = async () => {
         page = await getHomePage();
     }
 
-    console.log("Got page.");
     return page;
 };
 

--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -41,7 +41,7 @@ export const getWagtailPageOrRouteToTranslation = async (pageId) => {
     const currentLanguage = getLanguage();
     const translationInfo = page.data.translations;
 
-    const translationsLangCodes = Objects.keys(translationInfo);
+    const translationsLangCodes = Object.keys(translationInfo);
     // The default case:
     // The page you're viewing is in the current language, which means the
     // page's translations should lack the current language. Return the page.

--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -25,10 +25,10 @@ const routeToTranslation = (translationPageId) => {
     const [, section, cardNumber] = parseURLHash();
     const translatedPageUrl = `#${translationPageId}`;
     if (section) {
-        translatedPageUrl += section;
+        translatedPageUrl += `/${section}/`;
     }
     if (cardNumber) {
-        translatedPageUrl += cardNumber;
+        translatedPageUrl += `${cardNumber}`;
     }
     window.location = translatedPageUrl;
 };
@@ -50,6 +50,7 @@ export const getWagtailPageOrRouteToTranslation = async (pageId) => {
     }
     const translationPageId = translationInfo[translationLanguage];
     routeToTranslation(translationPageId);
+    return page;
 };
 
 export const getPage = async () => {

--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -102,6 +102,28 @@ export const getHomePathsInManifest = (manifest) => {
     return homePaths;
 };
 
+export const getWagtailPage = async (pageId) => {
+    const manifest = await getOrFetchManifest();
+    const pageUrl = manifest.pages[pageId];
+    let page = await getOrFetchWagtailPage(pageUrl);
+
+    const currentLanguage = getLanguage();
+    const translationInfo = page.data.translations;
+
+    // If Canoe ever adds three or more languages, the rest of the function must
+    // change.
+
+    const translationLanguage = Object.keys(translationInfo)[0];
+    if (currentLanguage !== translationLanguage) {
+        return page;
+    }
+
+    const translationPageId = translationInfo[translationLanguage];
+    const pathToTranslation = manifest.pages[translationPageId];
+    page = await getOrFetchWagtailPage(pathToTranslation);
+    return page;
+};
+
 export const getHomePage = async () => {
     const manifest = await getOrFetchManifest();
     const homePagePath = _getHomePathInCurrentLanguage(manifest);

--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -102,28 +102,6 @@ export const getHomePathsInManifest = (manifest) => {
     return homePaths;
 };
 
-export const getWagtailPage = async (pageId) => {
-    const manifest = await getOrFetchManifest();
-    const pageUrl = manifest.pages[pageId];
-    let page = await getOrFetchWagtailPage(pageUrl);
-
-    const currentLanguage = getLanguage();
-    const translationInfo = page.data.translations;
-
-    // If Canoe ever adds three or more languages, the rest of the function must
-    // change.
-
-    const translationLanguage = Object.keys(translationInfo)[0];
-    if (currentLanguage !== translationLanguage) {
-        return page;
-    }
-
-    const translationPageId = translationInfo[translationLanguage];
-    const pathToTranslation = manifest.pages[translationPageId];
-    page = await getOrFetchWagtailPage(pathToTranslation);
-    return page;
-};
-
 export const getHomePage = async () => {
     const manifest = await getOrFetchManifest();
     const homePagePath = _getHomePathInCurrentLanguage(manifest);

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -6,7 +6,7 @@
     <template if="{isBrowserSupported()}">
         <OnlineOrOffline></OnlineOrOffline>
         <Toast></Toast>
-      
+
         <Authentication if="{!isUserLoggedIn()}"></Authentication>
 
         <DataDownload if="{isUserLoggedIn()}"></DataDownload>
@@ -138,7 +138,7 @@
             },
 
             storeListener(previousStoreState, storeState) {
-                if(previousStoreState.language != storeState.language) {
+                if (previousStoreState.language != storeState.language) {
                     this.update();
                 }
             },


### PR DESCRIPTION
### NOTE
When you back-button to a page not in the current language, these changes grab the correct version of the page. This swap breaks the ability to go back.

You back-button to a URL, which grabs a new page and routes to the new page's URL. If you back-button again, you hit the old page's URL, which routes you to the new page's URL. You can’t escape this loop.