### PR TITLE
i18n-and-Image Error Handling

### DIFF
--- a/src/js/RenditionSelector.js
+++ b/src/js/RenditionSelector.js
@@ -33,7 +33,7 @@ const getPlatformSpecificRendition = () => {
     if (browser.name === "Safari") {
         renditionType = JPEG_RENDITION;
     } else {
-        renditionType = JPEG_RENDITION;
+        renditionType = WEBP_RENDITION;
     }
     return renditionType;
 };

--- a/src/js/RenditionSelector.js
+++ b/src/js/RenditionSelector.js
@@ -30,4 +30,27 @@ export function getImageUrls(images) {
 function _getRenditionUrl(renditions, includeDomain=false) {
     const filter_spec = navigator.userAgent.match(/Safari/g) ? RENDITION_FILTER_SPEC_SAFARI : RENDITION_FILTER_SPEC_DEFAULT;
     return `${includeDomain ? BACKEND_BASE_URL : ""}/media/${renditions[filter_spec]}`;
+    return Object.values(images).map(_getRenditionUrlWithoutDomain);
+}
+
+export const _getRenditionUrlWithoutDomain = (renditions) => {
+    const renditionPath = renditions[RENDITION_FORMAT];
+    if (!renditionPath) {
+        throw new MissingImageError(
+            `${RENDITION_FORMAT} image doesn't exist.
+            Renditions: ${JSON.stringify(renditions)}`
+        );
+    }
+    return `/media/${renditionPath}`;
 };
+
+function _getRenditionUrl(renditions) {
+    const renditionPath = renditions[RENDITION_FORMAT];
+    if (!renditionPath) {
+        throw new MissingImageError(
+            `${RENDITION_FORMAT} image doesn't exist.
+            Renditions: ${JSON.stringify(renditions)}`
+        );
+    }
+    return `${BACKEND_BASE_URL}/media/${renditionPath}`;
+}

--- a/src/js/RenditionSelector.js
+++ b/src/js/RenditionSelector.js
@@ -12,7 +12,7 @@ export class MissingImageError extends Error {
     }
 }
 
-export const getImagePath = async (imageId) => {
+export const getImageUrl = async (imageId) => {
     const manifest = await getOrFetchManifest();
     const images = manifest.images;
     const image = images[imageId];
@@ -23,9 +23,29 @@ export const getImagePath = async (imageId) => {
     return getRenditionUrl(image);
 };
 
-export function getImageUrls(images) {
-    return Object.values(images).map(getRenditionUrlWithoutDomain);
+export function getImagePaths(images) {
+    return Object.values(images).map(getRenditionPath);
 }
+
+const getRenditionUrl = (renditions) => {
+    return `${BACKEND_BASE_URL}${getRenditionPath(renditions)}`;
+};
+
+const getRenditionPath = (renditions) => {
+    return `/media/${getRendition(renditions)}`;
+};
+
+const getRendition = (renditions) => {
+    const renditionType = getPlatformSpecificRendition();
+    const rendition = renditions[renditionType];
+    if (!rendition) {
+        throw new MissingImageError(
+            `${renditionType} image doesn't exist.
+            Renditions: ${JSON.stringify(renditions)}`
+        );
+    }
+    return rendition;
+};
 
 const getPlatformSpecificRendition = () => {
     const { browser } = getPlatform();
@@ -37,27 +57,3 @@ const getPlatformSpecificRendition = () => {
     }
     return renditionType;
 };
-
-const getRenditionUrlWithoutDomain = (renditions) => {
-    const renditionType = getPlatformSpecificRendition();
-    const renditionPath = renditions[renditionType];
-    if (!renditionPath) {
-        throw new MissingImageError(
-            `${renditionType} image doesn't exist.
-            Renditions: ${JSON.stringify(renditions)}`
-        );
-    }
-    return `/media/${renditionPath}`;
-};
-
-function getRenditionUrl(renditions) {
-    const renditionType = getPlatformSpecificRendition();
-    const renditionPath = renditions[renditionType];
-    if (!renditionPath) {
-        throw new MissingImageError(
-            `${renditionType} image doesn't exist.
-            Renditions: ${JSON.stringify(renditions)}`
-        );
-    }
-    return `${BACKEND_BASE_URL}/media/${renditionPath}`;
-}

--- a/src/js/SiteDownloader.js
+++ b/src/js/SiteDownloader.js
@@ -7,7 +7,7 @@ import {
 import { storeWagtailPage } from "ReduxImpl/Store";
 import { dispatchToastEvent } from "js/Events";
 import { leftDifference } from "js/SetMethods";
-import { getImageUrls } from "js/RenditionSelector";
+import { getImagePaths } from "js/RenditionSelector";
 
 const trimDomain = (urlWithDomain) => urlWithDomain.replace(/^.*\/\/[^\/]+/, "");
 
@@ -51,7 +51,7 @@ export class SiteDownloader {
 
         const homePagePaths = getHomePathsInManifest(manifest);
         const manifestsPageUrls = new Set([...homePagePaths, ...Object.values(manifest.pages)]);
-        const manifestsMediaUrls = new Set(getImageUrls(manifest.images));
+        const manifestsMediaUrls = new Set(getImagePaths(manifest.images));
 
         const cachedPageUrls = await getCachedUrlsAndDeleteCruft(
             this.PAGES_CACHE,

--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -123,10 +123,9 @@ export const getHomePage = async () => {
     const homePagePath = homes[currentLanguage];
 
     if (homePagePath) {
-        const homePage = await getOrFetchWagtailPage(homePagePath);
-        return homePage;
+        return await getOrFetchWagtailPage(homePagePath);
     } else {
-        return _getNextAvailableHomePage(homes);
+        return await _getNextAvailableHomePage(homes);
     }
 };
 

--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -11,7 +11,7 @@
     </p>
 
     <script>
-        import { MissingImageError, getImagePath } from "js/RenditionSelector";
+        import { MissingImageError, getImageUrl } from "js/RenditionSelector";
 
         export default {
             state: {
@@ -24,7 +24,7 @@
                 let imagePath = "";
 
                 try {
-                    imagePath = await getImagePath(imageId);
+                    imagePath = await getImageUrl(imageId);
                 } catch (error) {
                     if (!(error instanceof MissingImageError)) {
                         throw error;


### PR DESCRIPTION
* Site works with one language and, without languages, fails gracefully.
* Site detects when the manifest lacks a rendition and fails gracefully.