### PR TITLE
73 other cookie issues

### DIFF
--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -69,7 +69,7 @@ export const login = async usernameAndPassword => {
     // Browsers refuse to set secure cookies from non https locations
     setCookie(JWT_TOKEN_STORAGE_KEY, token,
         window.location.protocol === "https:" ? ["secure"] : [],
-        {"max-age": 3e8, samesite: "strict"}
+        {"max-age": 3e8, samesite: "lax"}
     );
     localStorage.setItem(USERNAME_STORAGE_KEY, username);
     localStorage.setItem(USER_ID_STORAGE_KEY, userId);

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -9,7 +9,7 @@ const USER_GROUPS_STORAGE_KEY = "userGroups";
 const setCookie = (name, value, keyOnlyAttributes = [], attributes = {}) => {
     // sets name=value cookie
     // sets keyOnlyAttributes provided eg ['secure', 'samesite']
-    // sets value attributes provided eg {expires: 'Tue 19 Jan 2038 03:14:07 GMT'}
+    // sets value attributes provided eg {max-age: 3e8} to set expiry to 10 years in the future.
     // and potentially does vastly different things, because it does not escape inputs.
     document.cookie = Object.entries(attributes).reduce(
         (cookieString, keyValue) => `${cookieString};${keyValue[0]}=${keyValue[1]}`,
@@ -69,7 +69,7 @@ export const login = async usernameAndPassword => {
     // Browsers refuse to set secure cookies from non https locations
     setCookie(JWT_TOKEN_STORAGE_KEY, token,
         window.location.protocol === "https:" ? ["secure"] : [],
-        {expires: "Tue 19 Jan 2038 03:14:07 GMT", samesite: "strict"}
+        {"max-age": 3e8, samesite: "strict"}
     );
     localStorage.setItem(USERNAME_STORAGE_KEY, username);
     localStorage.setItem(USER_ID_STORAGE_KEY, userId);


### PR DESCRIPTION
More cookie issues.

This fixes catalpainternational/asteroid#73 on Geckoview. Really now. Hopefully.

First issue (inconsequential, but I was there anyway) is an misformatted date string for the absolute expiry, at least if I follow the MDN documentation there should be a comma after the DOW. Then I thought, these expiry datetime strings look error-prone, let's use max-age instead so we can have a simple integer value.

To (finally?) solve my login problem I had to change `samesite=strict` to `samesite=lax`. Otherwise the `document.cookie` simply stays... empty, and it seems canoe doesn't like that. The `samesite=strict` cookie gets stored allright, it just seems to not be available to the JS context. I'm not sure why that is or whether it's a bug in Gecko. It's not recorded as `httponly` so that's not it.

Can we have `samesite=lax` instead?