### PR TITLE
Store language in localStorage

### DIFF
--- a/modules/Translation.js
+++ b/modules/Translation.js
@@ -1,15 +1,17 @@
 import gettext_js from "gettext.js/dist/gettext.esm.js";
 import tetumTranslations from "../locale/json/tet.json";
-import { store } from "ReduxImpl/Store";
+import { store, getLanguage } from "ReduxImpl/Store";
 
 var i18n = gettext_js();
 
 // gettext.js seems to behave wrong when passed a nplurals 1 translation set
 // A temporary fix pending further investigation is to
 // iterate over all array value tranlsations adding a fake n=2 message
-Object.values(tetumTranslations).filter(Array.isArray).forEach((arr) => {
-    arr.push(arr[0]);
-});
+Object.values(tetumTranslations)
+    .filter(Array.isArray)
+    .forEach((arr) => {
+        arr.push(arr[0]);
+    });
 
 i18n.loadJSON(tetumTranslations, "messages");
 
@@ -24,7 +26,7 @@ export function ngettext(msgid, msgid_plural, n /* , extra */) {
     );
 }
 
-export function setLocale(locale) {
+function setLocale(locale) {
     i18n.setLocale(locale);
 }
 
@@ -35,6 +37,9 @@ function storeDispatch() {
     }
     previousStoreState = store.getState();
 }
+
+const userLanguage = getLanguage();
+setLocale(userLanguage);
 
 let previousStoreState = store.getState();
 const unsubscribe = store.subscribe(storeDispatch);

--- a/src/app.js
+++ b/src/app.js
@@ -6,17 +6,6 @@ import App from "RiotTags/App.riot.html";
 import { store, changeLanguage } from "ReduxImpl/Store";
 import "./scss/canoe.scss";
 
-const LANGUAGE_STORAGE_KEY = "userLanguage";
-const storedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
-
-if (!!storedLanguage) {
-    changeLanguage(storedLanguage);
-} else if (navigator.language.includes("en")) {
-    changeLanguage("en");
-} else {
-    changeLanguage("tet");
-}
-
 riot.install(function (component) {
     // all components will pass through here
     installTranslationPlugin(component);

--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,11 @@ import App from "RiotTags/App.riot.html";
 import { store, changeLanguage } from "ReduxImpl/Store";
 import "./scss/canoe.scss";
 
-changeLanguage('tet');
+if (navigator.language.includes("en")) {
+    changeLanguage("en");
+} else {
+    changeLanguage("tet");
+}
 
 riot.install(function (component) {
     // all components will pass through here

--- a/src/app.js
+++ b/src/app.js
@@ -3,10 +3,15 @@ import { installReduxPlugin } from "ReduxImpl/RiotReduxPlugin";
 import { installTranslationPlugin } from "RiotTranslationPlugin";
 
 import App from "RiotTags/App.riot.html";
-import { store, changeLanguage } from "ReduxImpl/Store";
+import { store, changeLanguage, getLanguage } from "ReduxImpl/Store";
 import "./scss/canoe.scss";
 
-if (navigator.language.includes("en")) {
+const LANGUAGE_STORAGE_KEY = "userLanguage";
+const storedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+
+if (!!storedLanguage) {
+    changeLanguage(storedLanguage);
+} else if (navigator.language.includes("en")) {
     changeLanguage("en");
 } else {
     changeLanguage("tet");

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import { installReduxPlugin } from "ReduxImpl/RiotReduxPlugin";
 import { installTranslationPlugin } from "RiotTranslationPlugin";
 
 import App from "RiotTags/App.riot.html";
-import { store, changeLanguage } from "ReduxImpl/Store";
+import { store } from "ReduxImpl/Store";
 import "./scss/canoe.scss";
 
 riot.install(function (component) {

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import { installReduxPlugin } from "ReduxImpl/RiotReduxPlugin";
 import { installTranslationPlugin } from "RiotTranslationPlugin";
 
 import App from "RiotTags/App.riot.html";
-import { store, changeLanguage, getLanguage } from "ReduxImpl/Store";
+import { store, changeLanguage } from "ReduxImpl/Store";
 import "./scss/canoe.scss";
 
 const LANGUAGE_STORAGE_KEY = "userLanguage";

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -1,5 +1,6 @@
 import { BACKEND_BASE_URL } from "js/urls";
 import { dispatchLoggedOutEvent, dispatchSiteDownloadEvent } from "js/Events";
+import { getLanguage, changeLanguage } from "ReduxImpl/Store";
 
 const USERNAME_STORAGE_KEY = "username";
 const USER_ID_STORAGE_KEY = "userId";
@@ -81,6 +82,7 @@ export const login = async usernameAndPassword => {
 export const logout = async () => {
     deleteCookie(JWT_TOKEN_STORAGE_KEY);
     localStorage.clear();
+    changeLanguage(getLanguage());
     dispatchLoggedOutEvent();
 };
 

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -1,6 +1,5 @@
 import { BACKEND_BASE_URL } from "js/urls";
 import { dispatchLoggedOutEvent, dispatchSiteDownloadEvent } from "js/Events";
-import { getLanguage, changeLanguage } from "ReduxImpl/Store";
 
 const USERNAME_STORAGE_KEY = "username";
 const USER_ID_STORAGE_KEY = "userId";
@@ -82,7 +81,6 @@ export const login = async usernameAndPassword => {
 export const logout = async () => {
     deleteCookie(JWT_TOKEN_STORAGE_KEY);
     localStorage.clear();
-    changeLanguage(getLanguage());
     dispatchLoggedOutEvent();
 };
 

--- a/src/js/actions/completion.js
+++ b/src/js/actions/completion.js
@@ -8,7 +8,6 @@
 import { storeCompletion, getCompletions } from "./actions_store";
 import { ON_ACTION_CHANGE, ON_COMPLETION_CHANGE } from "js/Events";
 import { intersection } from "js/SetMethods";
-import { isCourseInTheCurrentLanguage } from "js/utilities";
 
 const courses = new Map();
 

--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -13,26 +13,19 @@ import {
     SERVICE_WORKER_EVENT,
 } from "./_Reducers";
 
-export const changeLanguage = (language) => {
-    store.dispatch({ type: LANGUAGE_CHANGE, language: language });
-
-    const LANGUAGE_STORAGE_KEY = "userLanguage";
-    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
-};
-
-export const LANGUAGE_STORAGE_KEY = "userLanguage";
+const LANGUAGE_STORAGE_KEY = "userLanguage";
 
 export const getInitialLanguage = () => {
     const storedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
 
     if (!!storedLanguage) {
-        changeLanguage(storedLanguage);
+        localStorage.setItem(LANGUAGE_STORAGE_KEY, storedLanguage);
         return storedLanguage;
     } else if (navigator.language.includes("en")) {
-        changeLanguage("en");
+        localStorage.setItem(LANGUAGE_STORAGE_KEY, "en");
         return "en";
     } else {
-        changeLanguage("tet");
+        localStorage.setItem(LANGUAGE_STORAGE_KEY, "tet");
         return "tet";
     }
 };
@@ -81,6 +74,12 @@ export const serviceWorkerEvent = (event_type) => {
 
 export const getLanguage = () => {
     return store.getState().language;
+};
+
+export const changeLanguage = (language) => {
+    store.dispatch({ type: LANGUAGE_CHANGE, language: language });
+
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
 };
 
 export const storeBrowserSupport = (trueOrFalse) => {

--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -68,18 +68,18 @@ export const storeSiteDownloadedIs = (trueOrFalse) => {
     store.dispatch({ type: SITE_DOWNLOADED, siteIsDownloaded: trueOrFalse });
 };
 
+export const changeLanguage = (language) => {
+    store.dispatch({ type: LANGUAGE_CHANGE, language: language });
+
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+};
+
 export const serviceWorkerEvent = (event_type) => {
     store.dispatch({ type: SERVICE_WORKER_EVENT, event_type: event_type });
 };
 
 export const getLanguage = () => {
     return store.getState().language;
-};
-
-export const changeLanguage = (language) => {
-    store.dispatch({ type: LANGUAGE_CHANGE, language: language });
-
-    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
 };
 
 export const storeBrowserSupport = (trueOrFalse) => {

--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -48,6 +48,9 @@ export const storeSiteDownloadedIs = (trueOrFalse) => {
 
 export const changeLanguage = (language) => {
     store.dispatch({ type: LANGUAGE_CHANGE, language: language });
+
+    const LANGUAGE_STORAGE_KEY = "userLanguage";
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
 };
 
 export const serviceWorkerEvent = (event_type) => {

--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -15,11 +15,10 @@ import {
 
 const LANGUAGE_STORAGE_KEY = "userLanguage";
 
-export const getInitialLanguage = () => {
+const getInitialLanguage = () => {
     const storedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
 
     if (!!storedLanguage) {
-        localStorage.setItem(LANGUAGE_STORAGE_KEY, storedLanguage);
         return storedLanguage;
     } else if (navigator.language.includes("en")) {
         localStorage.setItem(LANGUAGE_STORAGE_KEY, "en");

--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -13,8 +13,37 @@ import {
     SERVICE_WORKER_EVENT,
 } from "./_Reducers";
 
+export const changeLanguage = (language) => {
+    store.dispatch({ type: LANGUAGE_CHANGE, language: language });
+
+    const LANGUAGE_STORAGE_KEY = "userLanguage";
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+};
+
+export const LANGUAGE_STORAGE_KEY = "userLanguage";
+
+export const getInitialLanguage = () => {
+    const storedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+
+    if (!!storedLanguage) {
+        changeLanguage(storedLanguage);
+        return storedLanguage;
+    } else if (navigator.language.includes("en")) {
+        changeLanguage("en");
+        return "en";
+    } else {
+        changeLanguage("tet");
+        return "tet";
+    }
+};
+
+const initialStoreState = {
+    language: getInitialLanguage(),
+};
+
 export const store = createStore(
     reducers,
+    initialStoreState,
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 );
 
@@ -44,13 +73,6 @@ export const storeManifest = (manifest) => {
 
 export const storeSiteDownloadedIs = (trueOrFalse) => {
     store.dispatch({ type: SITE_DOWNLOADED, siteIsDownloaded: trueOrFalse });
-};
-
-export const changeLanguage = (language) => {
-    store.dispatch({ type: LANGUAGE_CHANGE, language: language });
-
-    const LANGUAGE_STORAGE_KEY = "userLanguage";
-    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
 };
 
 export const serviceWorkerEvent = (event_type) => {


### PR DESCRIPTION
closes https://github.com/catalpainternational/canoe/issues/103

This PR does a few things:
1. When a user first loads the app, it looks for a `userLangage` in localStorage, which is where it is stored from their last visit. If they are a first-time user, then localStorage doesn't have the key.
2. Next it looks into their browser language. If the language is some variation of `en`, canoe changes the language to English.
3. Finally, if the browser's language is anything but English it sets the default language to Tetum.
4. When a user changes their language on the Settings page, it updates the language in Store and it stores the language in localStorage, so that it will persist in future sessions.

Feedback and suggestions welcome.