### PR TITLE
Fix feedback container and button margins

### DIFF
--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -679,7 +679,7 @@ LessonFeedback {
         display: flex;
         flex-flow: row wrap;
         justify-content: space-evenly;
-        margin-bottom: 3em;
+        margin: 2em 0;
     }
 
     .feedback-icon {
@@ -707,10 +707,6 @@ LessonFeedback {
 
     @mixin feedback-containers {
         text-align: center;
-
-        h3 {
-            margin-bottom: 2em;
-        }
     }
 
     .feedback-container {


### PR DESCRIPTION
Fix the margins per Pedro's comment https://github.com/catalpainternational/asteroid/issues/85#issuecomment-637919155

@pedro16v I added a margin to the feedback buttons (the smiley faces) so that the spacing would be consistent above and below them. Let me know if you disagree with the balance there.