### PR TITLE
get image on update as well as mount

### DIFF
--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -16,23 +16,28 @@
         export default {
             state: {
                 imagePath: "",
+                imageId: "",
+            },
+            onUpdated(props, state) {
+                this.setImagePath(props, state);
             },
 
-            async onMounted(props, state) {
+            onMounted(props, state) {
+                this.setImagePath(props, state);
+            },
+
+            setImagePath(props) {
                 const { imageId } = props;
-
-                let imagePath = "";
-
-                try {
-                    imagePath = await getImageUrl(imageId);
-                } catch (error) {
-                    if (!(error instanceof MissingImageError)) {
-                        throw error;
-                    }
+                if (this.state.imageId !== imageId) {
+                    getImageUrl(imageId).then(imagePath => {
+                        this.update({imagePath, imageId});
+                    }).catch(error => {
+                        if (!(error instanceof MissingImageError)) {
+                            throw error;
+                        }
+                    });
                 }
-
-                this.update({ imagePath });
-            },
+            }
         };
     </script>
 </ImageWrapper>

--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -26,16 +26,18 @@
                 this.setImagePath(props, state);
             },
 
-            setImagePath(props) {
+            async setImagePath(props) {
                 const { imageId } = props;
-                if (this.state.imageId !== imageId) {
-                    getImageUrl(imageId).then(imagePath => {
-                        this.update({imagePath, imageId});
-                    }).catch(error => {
-                        if (!(error instanceof MissingImageError)) {
-                            throw error;
-                        }
-                    });
+                if (this.state.imageId === imageId) {
+                    return;
+                }
+                try {
+                    const imagePath = await getImageUrl(imageId);
+                    this.update({imagePath, imageId});
+                } catch (error) {
+                    if (!(error instanceof MissingImageError)) {
+                        throw error;
+                    }
                 }
             }
         };


### PR DESCRIPTION
Fixes a problem with the first image showing up on multiple cards in lesson content.

The problem was that the code to retrieve the image path only ran on mount, and switching between two cards does not re-mount the card.

The fix is to run the code on update as well as on mount.

Investigating this showed up an important thing about the way riot works. 
If you do things in onBeforeMount or onBeforeUpdate ( where i would ideally like to do this kind of stuff ) if those things are async at all, then the actual mount or updates will not wait for them to complete, which can result in infinite updating, hence the guard against re-doing this by checking the imageId state property.