### PR TITLE
Store doesn't flatten QuickReferences.

### DIFF
--- a/src/js/redux/Store.js
+++ b/src/js/redux/Store.js
@@ -50,6 +50,12 @@ export const storeWagtailPage = (wagtailPage) => {
         case "elearning_content.LessonPage":
             store.dispatch({ type: ADDED_LESSON_PAGE, lesson: wagtailPage });
             break;
+        case "elearning_content.QuickReferenceRoot":
+            // Ignore the QuickReferences' root.
+            return;
+        case "elearning_content.QuickReferencePage":
+            // Ignore QuickReferences.
+            return;
         case "wagtailtrans.TranslatableSiteRootPage":
             // Ignore the i18nized site's root.
             return;


### PR DESCRIPTION
~Merge with catalpainternational/canoe-backend#37.~