### PR TITLE
Pending answer circle

### DIFF
--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -305,16 +305,24 @@ LessonObjective .objective {
 LessonContent .content {
     padding-bottom: $bottom-menu-height-no-footer;
 
-    raw, basiccard, quotecard, listcard, VideoCard, AudioCard  {
+    raw,
+    basiccard,
+    quotecard,
+    listcard,
+    VideoCard,
+    AudioCard {
         flex: 1;
         width: 100%;
     }
 
-    basiccard, quotecard, listcard {
+    basiccard,
+    quotecard,
+    listcard {
         text-align: left;
     }
 
-    VideoCard, AudioCard {
+    VideoCard,
+    AudioCard {
         text-align: center;
     }
 
@@ -357,8 +365,8 @@ LessonContent .content {
     }
 
     listcard {
-        width: 100%; 
-        
+        width: 100%;
+
         p {
             font-size: 1em;
         }
@@ -408,7 +416,8 @@ LessonContent .content {
         height: 50px;
     }
 
-    .speaker, .film {
+    .speaker,
+    .film {
         margin: 0 auto;
     }
 

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -536,15 +536,19 @@ TestPopupModal {
                 .warning {
                     height: 15px;
                     width: 18px;
-                    margin-right: 5px;
                     display: inline-block;
                     position: absolute;
-                    margin-left: 4px;
+                    margin-left: 5px;
                 }
 
                 .pendingAnswer {
                     background-color: $blue-1;
-                    border-radius: 10px;
+                    border-radius: 15px;
+                    width: 15px;
+                }
+
+                .warning {
+                    margin-left: 4px;
                 }
 
                 .checkbox {


### PR DESCRIPTION
Note the first commit has the scss changes, the 2nd is just prettier.

In response to @pedro16v 's [feedback](https://github.com/catalpainternational/olgeta/issues/222#issuecomment-633861879), the Pending answer symbol is now a real circle:
![localhost_8080_ (3)](https://user-images.githubusercontent.com/2395211/84695257-8bef1980-af18-11ea-9106-4474c8f8704f.png)
