### PR TITLE
#119: Adds "Continue as Guest" button to the login screen.

### DIFF
--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -104,6 +104,10 @@ export const getUsername = () => {
     return localStorage.getItem(USERNAME_STORAGE_KEY);
 };
 
+export const isGuestUser = () => {
+    return process.env.GUEST_USERNAME === getUsername();
+};
+
 export const getUserId = () => {
     return localStorage.getItem(USER_ID_STORAGE_KEY);
 };

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -7,7 +7,7 @@
         <OnlineOrOffline></OnlineOrOffline>
         <Toast></Toast>
 
-        <Authentication if="{!isUserLoggedIn()}"></Authentication>
+        <Login if="{!isUserLoggedIn()}"></Login>
 
         <DataDownload if="{isUserLoggedIn()}"></DataDownload>
 
@@ -56,7 +56,7 @@
         import Toast from "RiotTags/Components/Toast.riot.html";
         import OnlineOrOffline from "RiotTags/Components/OnlineOrOffline.riot.html";
 
-        import Authentication from "RiotTags/Screens/Authentication.riot.html";
+        import Login from "RiotTags/Screens/Login.riot.html";
         import Resources from "RiotTags/Screens/Resources.riot.html";
         import Profile from "RiotTags/Screens/Profile.riot.html";
         import Settings from "RiotTags/Screens/Settings.riot.html";
@@ -91,7 +91,7 @@
             },
 
             components: {
-                authentication: Authentication,
+                login: Login,
                 topmenu: TopMenu,
                 bottommenu: BottomMenu,
                 homepage: HomePage,

--- a/src/riot/Components/DataDownload.riot.html
+++ b/src/riot/Components/DataDownload.riot.html
@@ -7,13 +7,14 @@
         import { initialiseCompletions } from "Actions/completion.js";
         import { closeAndDeleteDB } from "Actions/actions_idb";
         import { dispatchLoggedInEvent } from "js/Events";
+        import { isGuestUser } from "js/AuthenticationUtilities";
 
         const EVERY_FIVE_MINUTES = 1000 * 60 * 5;
 
         export default {
             state: {
                 pagesPoller: null,
-                completionPoller: null
+                completionPoller: null,
             },
 
             onMounted() {
@@ -36,14 +37,15 @@
             },
 
             async prepDataForAppLaunch() {
-                await this.startCompletionsService();
+                if (!isGuestUser()) {
+                    await this.startCompletionsService();
+                    this.state.pagesPoller = window.setInterval(
+                        this.pollForWebpageChanges,
+                        EVERY_FIVE_MINUTES
+                    );
+                }
                 this.pollForWebpageChanges();
-
                 this.state.completionPoller = window.setInterval(updateApi, EVERY_FIVE_MINUTES);
-                this.state.pagesPoller = window.setInterval(
-                    this.pollForWebpageChanges,
-                    EVERY_FIVE_MINUTES
-                );
 
                 storeSiteDownloadedIs(true);
                 dispatchLoggedInEvent();
@@ -54,7 +56,7 @@
                 window.clearInterval(this.state.pagesPoller);
                 storeSiteDownloadedIs(false);
                 await closeAndDeleteDB();
-            }
+            },
         };
     </script>
 </DataDownload>

--- a/src/riot/Components/LoginForm.riot.html
+++ b/src/riot/Components/LoginForm.riot.html
@@ -1,0 +1,105 @@
+<LoginForm>
+    <form onsubmit="{loginUser}">
+        <h3 translate>Login</h3>
+        <div class="form-group">
+            <label for="username" translate>Username</label>
+            <input id="username" type="text" name="username" oninput="{clearError}" />
+        </div>
+        <div class="form-group">
+            <label for="password" translate>Password</label>
+            <input id="password" type="password" name="password" oninput="{clearError}" />
+        </div>
+        <div class="icon-box crossout">
+            <a onclick="{showPassword}">
+                <span class="eye"></span>
+                <span class="password-placement"
+                    >{state.isShowingPassword ? 'Hide' : 'Show'} Password</span
+                >
+            </a>
+        </div>
+        <div if="{state.errorExplanation}">
+            <span class="warning"></span>
+            <p class="error-message">{state.errorExplanation}</p>
+        </div>
+        <button
+            class="btn-primary"
+            type="submit"
+            disabled="{state.isLoginButtonDisabled}"
+            translate
+        >
+            Login
+        </button>
+    </form>
+    <script>
+        import { alertIfRequestWasMadeOffline } from "js/Errors";
+
+        export default {
+            state: {
+                isShowingPassword: false,
+                isLoginButtonDisabled: false,
+                errorExplanation: "",
+            },
+
+            getUsernameAndPasswordFromForm() {
+                const usernameInput = this.$("#username");
+                const passwordInput = this.$("#password");
+
+                const usernameAndPassword = {
+                    username: usernameInput.value,
+                    password: passwordInput.value,
+                };
+                return usernameAndPassword;
+            },
+
+            async loginUser(event) {
+                event.preventDefault();
+                const usernameAndPassword = this.getUsernameAndPasswordFromForm();
+                await this.disableFormButtonAndLogin(usernameAndPassword);
+            },
+
+            async disableFormButtonAndLogin(usernameAndPassword) {
+                try {
+                    this.update({
+                        isLoginButtonDisabled: true,
+                    });
+                    await this.props.loginFunction(usernameAndPassword);
+                } catch (error) {
+                    if (alertIfRequestWasMadeOffline(error)) {
+                    } else if (error.message === "400") {
+                        this.update({
+                            errorExplanation: "Invalid login credentials",
+                        });
+                    }
+                } finally {
+                    this.update({
+                        isLoginButtonDisabled: false,
+                    });
+                }
+            },
+
+            showPassword() {
+                const passwordElement = this.$("#password");
+                const eyeIcon = this.$(".icon-box");
+
+                if (passwordElement.type === "password") {
+                    passwordElement.type = "text";
+                    eyeIcon.classList.remove("crossout");
+                } else {
+                    passwordElement.type = "password";
+                    eyeIcon.classList.add("crossout");
+                }
+                this.update({
+                    isShowingPassword: !this.state.isShowingPassword,
+                });
+            },
+
+            clearError() {
+                if (this.state.errorExplanation) {
+                    this.update({
+                        errorExplanation: null,
+                    });
+                }
+            },
+        };
+    </script>
+</LoginForm>

--- a/src/riot/Screens/Login.riot.html
+++ b/src/riot/Screens/Login.riot.html
@@ -1,0 +1,110 @@
+<Login>
+    <div class="modal-background">
+        <span class="site-logo"></span>
+        <span class="login-image"></span>
+
+        <LoginForm loginFunction="{login}"></LoginForm>
+
+        <div class="extra-button-space">
+            <button onclick="{toggleLoginHelpModal}" translate>Forgot username or password?</button>
+            <button
+                if="{state.isLoginAsGuestAvailable}"
+                onclick="{toggleLoginAsGuestModal}"
+                translate
+            >
+                Login as a guest
+            </button>
+        </div>
+
+        <div is="logos" class="logo"></div>
+    </div>
+
+    <PopupModal if="{state.showLoginHelpModal}">
+        <span class="cross gray close-btn" onclick="{toggleLoginHelpModal}"></span>
+        <h2 class="header-no-image">Need help?</h2>
+        <ContactInformation toggleLoginHelpModal="{toggleLoginHelpModal}"></ContactInformation>
+    </PopupModal>
+
+    <PopupModal if="{state.showGuestLoginModal}">
+        <span class="cross gray close-btn" onclick="{toggleLoginAsGuestModal}"></span>
+        <h2 class="header-no-image">You're logging in as a guest</h2>
+        <p>
+            No learning progress will be saved while you are logged in as a guest. If you would like
+            to create an account, please
+            <a onclick="{switchToContactUsModal}">send us a message</a>.
+        </p>
+        <button class="btn-primary" onclick="{loginAsGuest}" translate>
+            Login as a guest
+        </button>
+    </PopupModal>
+
+    <script>
+        import LoginForm from "RiotTags/Components/LoginForm.riot.html";
+        import PopupModal from "RiotTags/Components/PopupModal.riot.html";
+        import ContactInformation from "RiotTags/Components/ContactInformation.riot.html";
+        import Logos from "RiotTags/Components/Logos.riot.html";
+
+        import { login } from "js/AuthenticationUtilities";
+
+        const GUEST_USERNAME = process.env.GUEST_USERNAME && `${process.env.GUEST_USERNAME}`;
+        const GUEST_PASSWORD = process.env.GUEST_PASSWORD && `${process.env.GUEST_PASSWORD}`;
+
+        export default {
+            state: {
+                showLoginHelpModal: false,
+                showGuestLoginModal: false,
+                isLoginAsGuestAvailable: false,
+            },
+
+            components: {
+                popupmodal: PopupModal,
+                contactinformation: ContactInformation,
+                loginform: LoginForm,
+                logos: Logos,
+            },
+
+            onBeforeMount(props, state) {
+                state.isLoginAsGuestAvailable = !!GUEST_USERNAME && !!GUEST_PASSWORD;
+            },
+
+            async loginAsGuest(event) {
+                event.preventDefault();
+                const usernameAndPassword = {
+                    username: GUEST_USERNAME,
+                    password: GUEST_PASSWORD,
+                };
+                await this.login(usernameAndPassword);
+            },
+
+            async login(usernameAndPassword) {
+                await login(usernameAndPassword);
+            },
+
+            fadePageBehindModal() {
+                const modalBackground = this.$(".modal-background");
+                modalBackground.classList.toggle("fade");
+            },
+
+            switchToContactUsModal() {
+                this.toggleLoginAsGuestModal();
+                this.toggleLoginHelpModal();
+            },
+
+            toggleLoginHelpModal() {
+                this.fadePageBehindModal();
+                const { showLoginHelpModal } = this.state;
+                this.update({
+                    showLoginHelpModal: !showLoginHelpModal,
+                });
+            },
+
+            toggleLoginAsGuestModal() {
+                this.fadePageBehindModal();
+                const { showGuestLoginModal } = this.state;
+                this.update({
+                    showGuestLoginModal: !showGuestLoginModal,
+                });
+            },
+        };
+    </script>
+</Login>

--- a/src/scss/_login.scss
+++ b/src/scss/_login.scss
@@ -1,10 +1,14 @@
-Authentication > div {
+Login > div {
+    $content-width: 18.75em;
+    $background-color: $tan;
+    $button-color: $blue-1;
+
     min-height: 100vh;
     flex-direction: column;
     align-items: center;
     display: flex;
     padding: 20px;
-    background-color: $tan;
+    background-color: $background-color;
 
     span.site-logo {
         margin-bottom: 20px;
@@ -31,8 +35,16 @@ Authentication > div {
         max-width: 400px;
     }
 
+    LoginForm {
+        max-width: $content-width;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+
+        margin-bottom: 1em;
+    }
+
     form {
-        max-width: 300px;
         width: 100%;
 
         h3 {
@@ -79,16 +91,25 @@ Authentication > div {
                 cursor: pointer;
             }
         }
+    }
 
-        div.login-help {
-            width: 100%;
-            display: block;
+    .extra-button-space {
+        display: flex;
+        flex-flow: row nowrap;
+        justify-content: space-between;
 
-            a {
-                margin-top: 2em;
-                display: block;
-                text-align: center;
-            }
+        max-width: $content-width;
+        width: 100%;
+
+        button {
+            font-size: 0.875em;
+            text-align: left;
+
+            color: $button-color;
+            background-color: $background-color;
+            border: none;
+
+            margin-top: 1em;
         }
     }
 


### PR DESCRIPTION
Closes catalpainternational/asteroid#119.
This PR enables guest-login in the most basic sense. We want to allow people without an account to preview the site. The login screen adds a button, "Login as Guest", that logs guests into a shared account.

`Login.riot.html` has two modals and `showModal` state variables. Since `Login`'s state got unwieldy, I split off the Login form into its own component, `LoginForm.riot.html`.

## How to get the branch working:
You must run catalpainternational/canoe-backend#48 and https://github.com/catalpainternational/asteroid/pull/147 to run this.

1. Create an account in Wagtail. The account doesn't need a group designation or admin privileges.
2. Add `GUEST_USERNAME` and `GUEST_PASSWORD` to your `canoe-environment.js`. The file will look something like:
```js
module.exports = {
    ...A bunch of values
    GUEST_USERNAME: [enter the username for the account you created in step 1],
    GUEST_PASSWORD: [enter the account's password],
};
```
3. Build and deploy canoe.

A button should appear on the login page, "Login as Guest":
<img width="300" src="https://user-images.githubusercontent.com/4751297/85462660-af970d00-b573-11ea-8f3e-cabdd2a44ab7.png" />
Note: this button hides when `canoe-environment` lacks a `GUESS_USERNAME` and `GUEST_PASSWORD`.

## Archive
~@katevoss I renamed `Authentication.riot.html` to `Login.riot.html`. What do you think?~