### PR TITLE
Fix tag filter home page

### DIFF
--- a/src/riot/WagtailPages/HomePage.riot.html
+++ b/src/riot/WagtailPages/HomePage.riot.html
@@ -182,7 +182,8 @@
 
             isCourseVisible(courseTags) {
                 const { selectedTags } = this.state;
-                return doPageTagsMatchSelections(courseTags, selectedTags);
+                const lowercaseCourseTags = courseTags.map(tag => tag.toLowerCase())
+                return doPageTagsMatchSelections(lowercaseCourseTags, selectedTags);
             },
         };
     </script>


### PR DESCRIPTION
Fixes the bug where tags weren't filtering courses on the home page. 

Closes https://github.com/catalpainternational/asteroid/issues/144.