### PR TITLE
LessonComplete Hide exam text and button if no exam

### DIFF
--- a/src/riot/Lesson/LessonComplete.riot.html
+++ b/src/riot/Lesson/LessonComplete.riot.html
@@ -21,9 +21,9 @@
                     <div>
                         <h2 translate>Good job!</h2>
                         <p>{ lessonCompleteMessage() }</p>
-                        <p>{ takeCourseExamMessage() }</p>
+                        <p if="{ courseHasExam() }">{ takeCourseExamMessage() }</p>
                     </div>
-                    <button class="btn-primary" onclick="{goToCourseExam}" translate>
+                    <button if="{ courseHasExam() }" class="btn-primary" onclick="{goToCourseExam}" translate>
                         Take Exam
                     </button>
                     <button class="btn-secondary" onclick="{goToCourseOverview}" translate>
@@ -34,7 +34,7 @@
                     <div>
                         <h2 translate>Amazing work!</h2>
                         <h3 translate>You've completed the course</h3>
-                        <p>{ passedExamMessage() }</p>
+                        <p if="{ courseHasExam() }">{ passedExamMessage() }</p>
                     </div>
                     <button class="btn-primary" onclick="{goHome}" translate>
                         Back to Courses
@@ -43,7 +43,7 @@
                         View Resources
                     </button>
                 </template>
-                <template if="{props.isCourseExamFinished && !props.passedExam}">
+                <template if="{ courseHasExam() }" if="{props.isCourseExamFinished && !props.passedExam}">
                     <div>
                         <h2 translate>Not quite!</h2>
                         <p>{ failedExamMessage() }</p>
@@ -80,6 +80,10 @@
                 const lessons = await getACoursesLessons(this.props.course.id);
                 const lessonSlugs = lessons.map((lesson) => lesson.slug);
                 this.update({ lessonSlugs });
+            },
+
+            courseHasExam() {
+                return this.props.course.exam_cards.length;
             },
 
             isCourseComplete() {


### PR DESCRIPTION
When completing the test of a course with no exam, exam buttons are shown and go nowhere
<img width="217" alt="Screenshot 2020-07-18 at 10 15 55" src="https://user-images.githubusercontent.com/1092029/87841362-b3525100-c8df-11ea-8a88-80cb5bd700e1.png">

This hides those buttons and text that refer to exams
<img width="203" alt="Screenshot 2020-07-18 at 10 17 53" src="https://user-images.githubusercontent.com/1092029/87841418-f6acbf80-c8df-11ea-9c27-dac2bac9dc66.png">
