### PR TITLE
Accidentally removed section title style

### DIFF
--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -140,6 +140,23 @@ p.feedback-message {
     };
 }
 
+h5.section-title {
+    text-transform: uppercase;
+    font-size: 14px;
+    font-weight: 400;
+    margin: 20px 0 10px 0;
+    display: flex;
+    align-items: center;
+    text-align: center;
+
+    &:after {
+        content: "";
+        flex: 1;
+        border-bottom: 1px solid $gray-6;
+        margin-left: 0.8em;
+    }
+}
+
 a {
     font-family: "GalanoGrotesqueAlt";
     text-decoration: none;


### PR DESCRIPTION
I removed it recently in https://github.com/catalpainternational/canoe/commit/dac93473035da5e53b5480c15967215f42754b1a, whoops!