### PR TITLE
quick (dirty?) fix to prevent crash on boot when offline, fixes #267

### DIFF
--- a/src/js/actions/actions_api.js
+++ b/src/js/actions/actions_api.js
@@ -30,6 +30,10 @@ export function getActions() {
                 action.date = new Date(action.date);
             });
             return actions;
+        })
+        .catch(err => {
+            console.warn(err);
+            return [];
         });
 }
 


### PR DESCRIPTION
This fixes #267 so that the app can boot when offline.

If you're offline, logically there'll be no *new* events (/"actions") for you, hence the empty set (well, array) is returned.

Following that semantic interpretation `getActions()` should actually return the set-union of clientside already-stored actions and serverside stored actions, instead of only the serverside stored actions, but meh.