### PR TITLE
270 incorrect cookie parsing

### DIFF
--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -32,7 +32,7 @@ const getCookie = (name) => {
         throw new Error(`Can't find "${name}" in cookie.`);
     }
 
-    return cookieValue.split("=")[1];
+    return cookieValue.substring(cookieValue.indexOf('=') + 1)
 };
 
 const deleteCookie = (name) => {

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -29,7 +29,7 @@ const getCookie = (name) => {
     });
 
     if (!cookieValue) {
-        throw new Error(`Can't find "${cookieValue}" in cookie.`);
+        throw new Error(`Can't find "${name}" in cookie.`);
     }
 
     return cookieValue.split("=")[1];


### PR DESCRIPTION

e6d9290 fixes an incorrect reference.

22e6721 fixes incorrect cookie parsing and closes #270.

Before this fix:
```
> document.cookie="huey=louie=dewey"
< "huey=louie=dewey"
> getCookie("huey")
< "louie"
```
Boooo!

After this fix:
```
> document.cookie="huey=louie=dewey"
< "huey=louie=dewey"
> getCookie("huey")
< "louie=dewey"
```

Hurray!