### PR TITLE
whitelist Firefox(-oids) for WebP image format support

### DIFF
--- a/src/js/Fetch.js
+++ b/src/js/Fetch.js
@@ -2,13 +2,15 @@ import { getAuthenticationToken } from "js/AuthenticationUtilities.js";
 import { APIMissingPageError } from "js/Errors";
 import { getPlatform } from "js/PlatformDetection";
 
+const WEBP_BROWSERS = ["Chrome", "Firefox"];
+
 export const getImageRequest = (url) => {
     const token = getAuthenticationToken();
     const { browser } = getPlatform();
     return new Request(url, {
         mode: "cors",
         headers: {
-            "Content-Type": browser.name === "Chrome" ? "image/webp" : "image/jpeg",
+            "Content-Type": browser.name in WEBP_BROWSERS ? "image/webp" : "image/jpeg",
             Authorization: `JWT ${token}`,
         },
     });


### PR DESCRIPTION
This scratches the short-term itch of Canoe not endowing Firefox and Appelflap with WebP images.

But from https://caniuse.com/?search=webp it seems that a blacklist based approach would be a better fit, it would come down to "give WebP to everything but IE and Safari". I think that in the wild, this would give a very low false positive ratio (where "positive" equals "supports WebP).
Also, for the future, modern Chrome supports [the phenomenal AVIF format](https://jakearchibald.com/2020/avif-has-landed/). Supporting it would yield big cache size reductions on browsers that can handle it.