### PR TITLE
elaborate on conditions requiring logging in; fixes #280

### DIFF
--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -7,16 +7,16 @@
         <OnlineOrOffline></OnlineOrOffline>
         <Toast></Toast>
 
-        <Login if="{!isUserLoggedIn()}"></Login>
+        <Login if="{userShouldLogin()}"></Login>
 
-        <LoadCompletions if="{isUserLoggedIn()}"></LoadCompletions>
+        <LoadCompletions if="{!userShouldLogin()}"></LoadCompletions>
 
         <LoadingDots
-            if="{Object.keys(state.wagtailPage).length === 0 && isUserLoggedIn()}"
+            if="{Object.keys(state.wagtailPage).length === 0 && !userShouldLogin()}"
             extrastyleclasses="light app"
         ></LoadingDots>
 
-        <template if="{isUserLoggedIn() && areCompletionsReady()}">
+        <template if="{!userShouldLogin() && areCompletionsReady()}">
             <DownloadSite></DownloadSite>
 
             <TopMenu
@@ -53,7 +53,7 @@
         import { isUserLoggedIn } from "js/AuthenticationUtilities";
         import { getPage } from "js/Routing";
         import { ON_LOG_IN, ON_LOG_OUT, ON_REQUEST_SITE_DOWNLOAD } from "js/Events";
-        import { isBrowserSupported, areCompletionsReady } from "ReduxImpl/Interface";
+        import { isBrowserSupported, areCompletionsReady, getManifestFromStore } from "ReduxImpl/Interface";
         import { logPageView } from "js/GoogleAnalytics";
 
         import HomePageJS from "js/HomePage";
@@ -141,13 +141,13 @@
                 });
 
                 window.addEventListener("hashchange", () => {
-                    if (this.isUserLoggedIn()) {
+                    if (!this.userShouldLogin()) {
                         this.route();
                         logPageView(window.location.hash);
                     }
                 });
 
-                if (this.isUserLoggedIn() && this.areCompletionsReady()) {
+                if (!this.userShouldLogin() && this.areCompletionsReady()) {
                     // If user returns to site and is logged in.
                     this.route();
                 }
@@ -181,8 +181,11 @@
                 return areCompletionsReady();
             },
 
-            isUserLoggedIn() {
-                return isUserLoggedIn();
+            userShouldLogin() {
+                return !(
+                    localStorage.getItem("fetch_result_indicates_authed") === "true"
+                    || Object.keys(getManifestFromStore()).length && isUserLoggedIn()
+                );
             },
 
             createHomePage(aWagtailPage) {


### PR DESCRIPTION
Fixes #280 

When there's no manifest & home page etc in the Cache, most Riot components will crash because they (or the stack below) don't handle the HTTP 403s arising from trying to fetch the manifest.
However, since #274, the 403s result in recorded evidence that the user is logged out, so on the next refresh the login screen is shown (as it should be).

This PR attempts to remedy the situation by presenting the login screen when the manifest is empty. Thus, a first load with empty caches will take users to the login screen, but a load with caches injected from outer space (offline Appelflap magic) will not strand users on the login screen, as in that case there'll be a manifest in the Cache, deo volente.