### PR TITLE
CanoeTube frontend

### DIFF
--- a/src/js/RenditionSelector.js
+++ b/src/js/RenditionSelector.js
@@ -1,4 +1,4 @@
-import { BACKEND_BASE_URL } from "js/urls";
+import { BACKEND_BASE_URL, MEDIA_PATH } from "js/urls";
 import { getOrFetchManifest } from "js/WagtailPagesAPI";
 import { getPlatform } from "js/PlatformDetection";
 import { MissingImageError } from "js/Errors";
@@ -26,7 +26,7 @@ const getRenditionUrl = (renditions) => {
 };
 
 const getRenditionPath = (renditions) => {
-    return `/media/${getRendition(renditions)}`;
+    return `${MEDIA_PATH}/${getRendition(renditions)}`;
 };
 
 const getRendition = (renditions) => {

--- a/src/js/SiteDownloader.js
+++ b/src/js/SiteDownloader.js
@@ -5,6 +5,7 @@ import {
     getHomePathsInManifest,
 } from "js/WagtailPagesAPI";
 import { dispatchToastEvent } from "js/Events";
+import { getPlatform } from "js/PlatformDetection";
 import { leftDifference } from "js/SetMethods";
 import { getImagePaths } from "js/RenditionSelector";
 import { getAuthenticationToken } from "js/AuthenticationUtilities";
@@ -58,6 +59,12 @@ const addCachedPagesToRedux = async () => {
 };
 
 export default class SiteDownloader {
+
+    async precacheVideos () {
+        if (!getPlatform().inAppelflap) return;
+        // TODO: interface with Appelflap/Eekhoorn to store video
+    }
+
     async requestTheSitesPagesAndImages() {
         const manifest = await getOrFetchManifest();
 
@@ -88,6 +95,7 @@ export default class SiteDownloader {
             await fetchImage(imagePath);
         }
         await addCachedPagesToRedux();
+        await this.precacheVideos();
 
         if (pagesToFetch.size > 0 || imagesToFetch.size > 0) {
             dispatchToastEvent(gettext("Site download is complete!"));

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -1,2 +1,3 @@
 export const BACKEND_BASE_URL = `${process.env.API_BASE_URL}`;
 export const WAGTAIL_MANIFEST_URL = `${BACKEND_BASE_URL}/manifest`;
+export const MEDIA_PATH = "/media";

--- a/src/riot/Components/Raw.riot.html
+++ b/src/riot/Components/Raw.riot.html
@@ -1,23 +1,55 @@
 <raw>
     <script>
         import { component } from "riot";
+        import { BACKEND_BASE_URL, MEDIA_PATH } from "js/urls";
         import ImageWrapper from "RiotTags/Components/ImageWrapper.riot.html";
+        import { getPlatform } from "js/PlatformDetection";
+        import { getOrFetchManifest } from "js/WagtailPagesAPI";
+
 
         const mountImage = component(ImageWrapper);
+        const canoetuberex = RegExp("canoetube://[0-9]+").compile();
+        const inAppelflap = getPlatform().inAppelflap;
         export default {
             setInnerHTML() {
                 this.root.innerHTML = this.props.html;
                 this.$$("embed").forEach(embed => {
-                    mountImage(
-                        embed.insertAdjacentElement(
-                            "afterend",
-                            document.createElement("div")
-                        ),
-                        {
-                            imageId: embed.getAttribute("id"),
-                            alt: embed.getAttribute("alt"),
-                        }
-                    );
+                    switch (embed.getAttribute("embedtype")) {
+                        case "media":
+                            const the_url = embed.getAttribute("url");
+                            if (canoetuberex.test(the_url)) {
+                                getOrFetchManifest()
+                                    .then(mfest => Object.values(mfest.canoetube_manifest[the_url]).sort((el1,el2) => el1.size - el2.size)[0])
+                                    .then(smallestvideo => {
+                                        // TODO: probe/use locally stored Eekhoorn-served copy if we're inAppelflap
+                                        // Potentially, we could do some intelligent format-picking here depending on browser (Safari doesn't do VP8), screen size and connection speed (perusing https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation)
+                                        const video = document.createElement("video");
+                                        video.setAttribute("src", `${BACKEND_BASE_URL}${MEDIA_PATH}/${smallestvideo.mediapath}`);
+                                        video.setAttribute("controls", "");
+                                        video.innerText = "Alas! Video is not supported on your platform.";
+                                        embed.replaceWith(video);
+                                    })
+                                .catch(console.error);
+                            } else {
+                                // TODO: test for other things we may wish to embed, see #283
+                                console.warn(`Unhandled media embed URL: ${the_url}`);
+                            }
+                            break;
+                        case "image":
+                            mountImage(
+                            embed.insertAdjacentElement(
+                                "afterend",
+                                document.createElement("div")
+                            ),
+                                {
+                                    imageId: embed.getAttribute("id"),
+                                    alt: embed.getAttribute("alt"),
+                                }
+                            );
+                            break;
+                        default:
+                            console.warn(`Unhandled embedtype ${embed.getAttribute("embedtype")}`);
+                    }
                 });
             },
 


### PR DESCRIPTION
Companion PR in canoe-backend: catalpainternational/canoe-backend#76

This lays some groundwork for "CanoeTube" self-hosted videos, with indicated entry points for doing Appelflap/Eekhoorn-related off-web in-Android-app storage.

There's some improvements to be made, I'll add inline comments to draw attention to those areas.