### PR TITLE
add preboot stage for app, determine blank/preseeded state before booting

### DIFF
--- a/src/index.hbs
+++ b/src/index.hbs
@@ -86,6 +86,49 @@
             max-height: 100px;
         }
     </style>
+        <script>
+        const MANIFEST_CACHE_NAME = "manifest-cache";
+        const MANIFEST_URL = "{{{ htmlWebpackPlugin.options.api_base_url }}}/manifest";
+        const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";
+        var webpack_script_sources = [
+            {{# each htmlWebpackPlugin.tags.bodyTags }}
+            new DOMParser().parseFromString(new DOMParser().parseFromString("{{this}}", "text/html").documentElement.innerText, "text/html").scripts[0].src,
+            {{/each}}
+        ];
+        window.onload = (event) => {
+            // First deduce whether we're in blank slate state vs preseeded state, by checking for a cached manifest.
+            // Only then boot the app, so that Riot can synchronously access this fact.
+            caches.keys()
+                .then(cachenames => {
+                    if (cachenames.indexOf(MANIFEST_CACHE_NAME) < 0) {
+                        sessionStorage.setItem(EMPTY_SLATE_BOOT_KEY, true);
+                        return true;
+                    }
+                    else {
+                        return caches.open(MANIFEST_CACHE_NAME)
+                        .then(thecache => {
+                            return thecache.match(MANIFEST_URL);
+                        })
+                        .then(manifest => {
+                            let is_empty_slate_boot = (manifest === undefined);
+                            sessionStorage.setItem(EMPTY_SLATE_BOOT_KEY, is_empty_slate_boot);
+                            return is_empty_slate_boot;
+                        })
+                    }
+                })
+                .catch(err => console.error)
+                .then(_whevs => {
+                    webpack_script_sources.forEach(src => {
+                        script = document.createElement("script");
+                        script.src = src;
+                        script.type = 'application/javascript';
+                        script.async = false;
+                        script.defer = true;
+                        document.head.appendChild(script);
+                    });
+                });
+        };
+    </script>
 </body>
 
 </html>

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -7,7 +7,8 @@ const USERNAME_STORAGE_KEY = "username";
 const USER_ID_STORAGE_KEY = "userId";
 const JWT_TOKEN_STORAGE_KEY = "token";
 const USER_GROUPS_STORAGE_KEY = "userGroups";
-const USER_IS_AUTHED_STORAGE_KEY = "fetch_result_indicates_authed";
+const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";
+export const USER_IS_AUTHED_STORAGE_KEY = "fetch_result_indicates_authed";
 
 const setCookie = (name, value, keyOnlyAttributes = [], attributes = {}) => {
     // sets name=value cookie
@@ -65,7 +66,7 @@ export const login = async (usernameAndPassword) => {
     localStorage.setItem(USER_ID_STORAGE_KEY, userId);
     localStorage.setItem(USER_GROUPS_STORAGE_KEY, groups);
     setIsAuthed(true);
-
+    sessionStorage.removeItem(EMPTY_SLATE_BOOT_KEY);
     dispatchSiteDownloadEvent();
 };
 

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -50,7 +50,7 @@
     </template>
 
     <script>
-        import { isUserLoggedIn } from "js/AuthenticationUtilities";
+        import { isUserLoggedIn, USER_IS_AUTHED_STORAGE_KEY } from "js/AuthenticationUtilities";
         import { getPage } from "js/Routing";
         import { ON_LOG_IN, ON_LOG_OUT, ON_REQUEST_SITE_DOWNLOAD } from "js/Events";
         import { isBrowserSupported, areCompletionsReady, getManifestFromStore } from "ReduxImpl/Interface";
@@ -182,10 +182,10 @@
             },
 
             userShouldLogin() {
-                return !(
-                    localStorage.getItem("fetch_result_indicates_authed") === "true"
-                    || Object.keys(getManifestFromStore()).length && isUserLoggedIn()
-                );
+                const is_deauthed = localStorage.getItem(USER_IS_AUTHED_STORAGE_KEY) === "false";
+                const is_firstboot = sessionStorage.getItem("empty_slate_boot") === "true";
+                const is_user_logged_in = isUserLoggedIn();
+                return is_deauthed || is_firstboot || !is_user_logged_in;
             },
 
             createHomePage(aWagtailPage) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,10 +143,12 @@ module.exports = (env) => {
             new HtmlWebpackPlugin({
                 title: projectConfiguration.SITE_NAME,
                 template: path.resolve(__dirname, "src/index.hbs"),
+                inject: false,
                 favicon: projectConfiguration.FAVICON_PATH,
                 favicon_path: path.basename(projectConfiguration.FAVICON_PATH),
                 include_ga: Boolean(environmentConfiguration.GA_TAG),
                 ga_tag: environmentConfiguration.GA_TAG,
+                api_base_url: environmentConfiguration.API_BASE_URL,
                 theme_color: projectConfiguration.THEME_COLOR,
                 background_color: projectConfiguration.BACKGROUND_COLOR,
             }),


### PR DESCRIPTION
Fixes #281 
Fixes #269

Brings when the app bundle boots under our control (always nice to have the option of exercising control.). In this case it's used to determine "blank slate" vs "preseeded slate" state, and only when that has been determined, boot the app, which can then access that information in a synchronous fashion, so that the Riot template logic works without modification.

This fixes shortcomings (well, outright brokenness) of the previous implementation. As I've mentioned elsewhere, `ReduxImpl/Interface.getManifestFromStore()` doesn't actually always give you the manifest (I was enticed by the name, but was also wondering how it would do that in synchronous code, since the manifest is in a Cache... I shouldn't have been so trusty). While a probe for a manifest is an appropriate method to determine "is this a from scratch boot, or are we running on teleported caches", the answer can only come in an async way (because that's how the Cache interface works), while the code that needs to know — Riot template conditionals — is synchronous.