### PR TITLE
Pre-establish the state of the slate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import "babel-polyfill";
 
 import { subscribeToStore, getServiceWorkerState } from "ReduxImpl/Interface";
 import { initializeServiceWorker } from "js/ServiceWorkerManagement";
+import { BACKEND_BASE_URL } from "js/urls.js";
 
 let currentServiceWorkerState = getServiceWorkerState();
 
@@ -24,8 +25,10 @@ subscribeToStore(() => {
             break;
         case "controlling":
             // hide the loading splash
-            document.querySelector("#preapp-messages").hidden = true;
-            import(/* webpackChunkName: "app" */ "./app.js");
+            record_bootstate().then(_is_nonblank_slate => {
+                document.querySelector("#preapp-messages").hidden = true;
+                import(/* webpackChunkName: "app" */ "./app.js");
+            });
             break;
         case "update-waiting":
             // TODO should we reload? it might interrupt something
@@ -38,5 +41,27 @@ subscribeToStore(() => {
     // store state for next time
     currentServiceWorkerState = getServiceWorkerState();
 });
+
+
+const record_bootstate = () => {
+    // Sets a sessionStorage item signifying whether we are booting into a preseeded state
+    // (either through Appelflap cache injection, or autonomous buildup), or into a
+    // blank slate. We use the presence of the manifest as an indication for this.
+    // Can be used as a fence by awaiting its promise.
+    // Returns true when a manifest can be found, false otherwise.
+    const MANIFEST_CACHE_NAME = "manifest-cache";
+    const MANIFEST_URL = `${BACKEND_BASE_URL}/manifest`;
+    const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";
+
+    return caches.keys()
+        .then(cachenames => cachenames.indexOf(MANIFEST_CACHE_NAME) > -1
+            && caches.open(MANIFEST_CACHE_NAME)
+                .then(thecache => thecache.match(MANIFEST_URL) !== undefined)
+        )
+        .then(manifest_is_extant => {
+            sessionStorage.setItem(EMPTY_SLATE_BOOT_KEY, !manifest_is_extant);
+            return manifest_is_extant;
+        });
+};
 
 initializeServiceWorker();

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -7,7 +7,8 @@ const USERNAME_STORAGE_KEY = "username";
 const USER_ID_STORAGE_KEY = "userId";
 const JWT_TOKEN_STORAGE_KEY = "token";
 const USER_GROUPS_STORAGE_KEY = "userGroups";
-const USER_IS_AUTHED_STORAGE_KEY = "fetch_result_indicates_authed";
+const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";
+export const USER_IS_AUTHED_STORAGE_KEY = "fetch_result_indicates_authed";
 
 const setCookie = (name, value, keyOnlyAttributes = [], attributes = {}) => {
     // sets name=value cookie
@@ -65,7 +66,7 @@ export const login = async (usernameAndPassword) => {
     localStorage.setItem(USER_ID_STORAGE_KEY, userId);
     localStorage.setItem(USER_GROUPS_STORAGE_KEY, groups);
     setIsAuthed(true);
-
+    sessionStorage.removeItem(EMPTY_SLATE_BOOT_KEY);
     dispatchSiteDownloadEvent();
 };
 

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -8,7 +8,7 @@ const USER_ID_STORAGE_KEY = "userId";
 const JWT_TOKEN_STORAGE_KEY = "token";
 const USER_GROUPS_STORAGE_KEY = "userGroups";
 const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";
-export const USER_IS_AUTHED_STORAGE_KEY = "fetch_result_indicates_authed";
+const USER_IS_AUTHED_STORAGE_KEY = "fetch_result_indicates_authed";
 
 const setCookie = (name, value, keyOnlyAttributes = [], attributes = {}) => {
     // sets name=value cookie
@@ -85,6 +85,13 @@ export const getAuthenticationToken = () => {
 export const isUserLoggedIn = () => {
     const auth_status_denoted = localStorage.getItem(USER_IS_AUTHED_STORAGE_KEY);
     return (auth_status_denoted === null || auth_status_denoted === "true");
+};
+
+export const userShouldLogin = () => {
+    const is_deauthed = localStorage.getItem(USER_IS_AUTHED_STORAGE_KEY) === "false";
+    const is_firstboot = sessionStorage.getItem(EMPTY_SLATE_BOOT_KEY) === "true";
+    const is_user_logged_in = isUserLoggedIn();
+    return is_deauthed || is_firstboot || !is_user_logged_in;
 };
 
 export const getUsername = () => {

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -50,7 +50,7 @@
     </template>
 
     <script>
-        import { isUserLoggedIn, USER_IS_AUTHED_STORAGE_KEY } from "js/AuthenticationUtilities";
+        import { userShouldLogin } from "js/AuthenticationUtilities";
         import { getPage } from "js/Routing";
         import { ON_LOG_IN, ON_LOG_OUT, ON_REQUEST_SITE_DOWNLOAD } from "js/Events";
         import { isBrowserSupported, areCompletionsReady, getManifestFromStore } from "ReduxImpl/Interface";
@@ -182,10 +182,7 @@
             },
 
             userShouldLogin() {
-                const is_deauthed = localStorage.getItem(USER_IS_AUTHED_STORAGE_KEY) === "false";
-                const is_firstboot = sessionStorage.getItem("empty_slate_boot") === "true";
-                const is_user_logged_in = isUserLoggedIn();
-                return is_deauthed || is_firstboot || !is_user_logged_in;
+                return userShouldLogin();
             },
 
             createHomePage(aWagtailPage) {

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -50,7 +50,7 @@
     </template>
 
     <script>
-        import { isUserLoggedIn } from "js/AuthenticationUtilities";
+        import { isUserLoggedIn, USER_IS_AUTHED_STORAGE_KEY } from "js/AuthenticationUtilities";
         import { getPage } from "js/Routing";
         import { ON_LOG_IN, ON_LOG_OUT, ON_REQUEST_SITE_DOWNLOAD } from "js/Events";
         import { isBrowserSupported, areCompletionsReady, getManifestFromStore } from "ReduxImpl/Interface";
@@ -182,10 +182,10 @@
             },
 
             userShouldLogin() {
-                return !(
-                    localStorage.getItem("fetch_result_indicates_authed") === "true"
-                    || Object.keys(getManifestFromStore()).length && isUserLoggedIn()
-                );
+                const is_deauthed = localStorage.getItem(USER_IS_AUTHED_STORAGE_KEY) === "false";
+                const is_firstboot = sessionStorage.getItem("empty_slate_boot") === "true";
+                const is_user_logged_in = isUserLoggedIn();
+                return is_deauthed || is_firstboot || !is_user_logged_in;
             },
 
             createHomePage(aWagtailPage) {


### PR DESCRIPTION
Fixes #269 
Supersedes #289 

As mentioned in #289:
> This is used to determine "blank slate" vs "preseeded slate" state, and only once that has been determined, boot the app, which can then access that information in a synchronous fashion, so that the Riot template logic works without modification.

> This fixes shortcomings (well, outright brokenness) of the previous implementation. As I've mentioned elsewhere, `ReduxImpl/Interface.getManifestFromStore()` doesn't actually always give you the manifest (I was enticed by the name, but was also wondering how it would do that in synchronous code, since the manifest is in a Cache... I shouldn't have been so trusty). While a probe for a manifest is an appropriate method to determine "is this a from scratch boot, or are we running on teleported caches", the answer can only come in an async way (because that's how the Cache interface works), while the code that needs to know — Riot template conditionals — is synchronous.