### PR TITLE
Clean import references

### DIFF
--- a/src/js/Fetch.js
+++ b/src/js/Fetch.js
@@ -1,4 +1,4 @@
-import { getAuthenticationToken, setIsAuthed } from "js/AuthenticationUtilities.js";
+import { getAuthenticationToken, setIsAuthed } from "js/AuthenticationUtilities";
 import { APIMissingPageError } from "js/Errors";
 import { getPlatform } from "js/PlatformDetection";
 

--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -3,7 +3,7 @@ import {
     getOrFetchWagtailPage,
     getOrFetchManifest,
     getHomePage,
-} from "js/WagtailPagesAPI.js";
+} from "js/WagtailPagesAPI";
 import { getLanguage } from "ReduxImpl/Interface";
 import { PageLacksTranslationDataError } from "js/Errors";
 

--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -1,5 +1,5 @@
-import { BACKEND_BASE_URL, WAGTAIL_MANIFEST_URL } from "js/urls.js";
-import { isGuestUser } from "js/AuthenticationUtilities.js";
+import { BACKEND_BASE_URL, WAGTAIL_MANIFEST_URL } from "js/urls";
+import { isGuestUser } from "js/AuthenticationUtilities";
 import {
     storeWagtailPage,
     getWagtailPageFromStore,

--- a/src/js/actions/actions_api.js
+++ b/src/js/actions/actions_api.js
@@ -1,6 +1,6 @@
-import { getAuthenticationToken } from "../AuthenticationUtilities.js";
-import { BACKEND_BASE_URL } from "../urls.js";
-import { fetch_and_denote_unauthenticatedness as fetch} from "../Fetch.js";
+import { getAuthenticationToken } from "js/AuthenticationUtilities";
+import { BACKEND_BASE_URL } from "js/urls";
+import { fetch_and_denote_unauthenticatedness as fetch} from "js/Fetch";
 
 const ACTIONS_ENDPOINT_URL = `${BACKEND_BASE_URL}/progress/actions`;
 

--- a/src/js/actions/actions_store.js
+++ b/src/js/actions/actions_store.js
@@ -12,7 +12,7 @@ import {
 } from "./actions_idb";
 import { postAction, getActions } from "./actions_api";
 import { make_uuid32 } from "./make_uuid32";
-import { ON_ACTION_CHANGE } from "../Events";
+import { ON_ACTION_CHANGE } from "js/Events";
 
 const COMPLETION_ACTION_TYPE = "completion";
 const EXAM_ACTION_TYPE = "exam";

--- a/src/js/cacheManager/cacheManager.js
+++ b/src/js/cacheManager/cacheManager.js
@@ -1,7 +1,7 @@
 /// CacheManager
 // a set of simple functions to easily wrap and expose cache operations
 
-import { BACKEND_BASE_URL } from "../../js/urls";
+import { BACKEND_BASE_URL } from "js/urls";
 
 // requires ignoreVary:true but I am not sure why!
 const CACHE_OPTIONS = { ignoreVary: true };

--- a/src/riot/Components/LoadCompletions.riot.html
+++ b/src/riot/Components/LoadCompletions.riot.html
@@ -11,7 +11,7 @@
             pullCompletionsIntoMemory,
             clearInMemoryCompletions,
         } from "js/CompletionInterface";
-        import { updateApi, updateIdb } from "Actions/actions_store.js";
+        import { updateApi, updateIdb } from "Actions/actions_store";
         import { closeAndDeleteDB } from "Actions/actions_idb";
 
         const EVERY_FIVE_MINUTES = 1000 * 60 * 5;

--- a/src/riot/Lesson/AudioCard.riot.html
+++ b/src/riot/Lesson/AudioCard.riot.html
@@ -16,7 +16,7 @@
             isItemCached,
             addToCache,
             deleteItemFromCache
-        } from "js/cacheManager/cacheManager.js";
+        } from "js/cacheManager/cacheManager";
         import { logClickedPlayOnVideo } from "js/GoogleAnalytics";
 
         export default {

--- a/src/riot/Lesson/VideoCard.riot.html
+++ b/src/riot/Lesson/VideoCard.riot.html
@@ -23,7 +23,7 @@
             isItemCached,
             addToCache,
             deleteItemFromCache
-        } from "js/cacheManager/cacheManager.js";
+        } from "js/cacheManager/cacheManager";
         import { logClickedPlayOnVideo } from "js/GoogleAnalytics";
 
         export default {


### PR DESCRIPTION
# Description

Clean up import references in the code;
- consistently use 'aliases': even if we choose to remove these later, at least we have a consistent starting point to remove them.
- remove superfluous '.js' file extensions: babel does a much better job of figuring these out on its own.  They can cause problems for tests (rare , but it does happen). And we can arbitrarily switch to TS imports later, because babel will look after it.