### PR TITLE
Remove react specific references

### DIFF
--- a/messages_scan.js
+++ b/messages_scan.js
@@ -22,7 +22,7 @@ const jsParser = extractor
             comments: jsParserCommentOptions,
         }),
     ])
-    .parseFilesGlob("./src/**/*.@(ts|js|tsx|jsx)");
+    .parseFilesGlob("./src/**/*.@(ts|js|mjs|cjs)");
 
 extractor
     .createHtmlParser([


### PR DESCRIPTION
This is the last reference to react that I could find, that we should get rid of.

Instead it's been replaced with references to `cjs` and `mjs` files that are likely to be relevant to us while we still have some sites running node < v14