### PR TITLE
Clean webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const webpack = require("webpack");
-const { mergeWithCustomize, customizeArray } = require('webpack-merge');
+const { mergeWithCustomize, customizeArray } = require("webpack-merge");
 const path = require("path");
-const fs = require("fs");
 
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const { InjectManifest } = require("workbox-webpack-plugin");
@@ -24,7 +23,9 @@ module.exports = (env) => {
     // read the environment configuration
     const environmentConfiguration = Object.assign(
         defaultEnvironmentConfiguration,
-        env && env.ENVIRONMENT_CONFIG_PATH ? require(env.ENVIRONMENT_CONFIG_PATH) : {}
+        env && env.ENVIRONMENT_CONFIG_PATH
+            ? require(env.ENVIRONMENT_CONFIG_PATH)
+            : {}
     );
 
     // read the project configuration
@@ -35,11 +36,18 @@ module.exports = (env) => {
 
     // merge environment and project configurations for use in webpack compilation
     // webpack.DefinePlugin will replace process.env.CONFIG_KEY with configured valuea
-    const processEnvironment = Object.keys(environmentConfiguration).reduce((prev, next) => {
-        prev[`process.env.${next}`] = JSON.stringify(environmentConfiguration[next]);
-        return prev;
-    }, {});
-    processEnvironment["process.env.SITE_NAME"] = JSON.stringify(projectConfiguration.SITE_NAME);
+    const processEnvironment = Object.keys(environmentConfiguration).reduce(
+        (prev, next) => {
+            prev[`process.env.${next}`] = JSON.stringify(
+                environmentConfiguration[next]
+            );
+            return prev;
+        },
+        {}
+    );
+    processEnvironment["process.env.SITE_NAME"] = JSON.stringify(
+        projectConfiguration.SITE_NAME
+    );
 
     const baseConfig = {
         context: __dirname,
@@ -61,7 +69,7 @@ module.exports = (env) => {
             contentBase: path.resolve(__dirname, "dist"),
         },
         resolve: {
-            extensions: ['.ts', '.js', '.json', ".riot.html"],
+            extensions: [".ts", ".js", ".json", ".riot.html"],
             modules: [path.resolve(__dirname, "src")],
             alias: {
                 RiotTags: path.resolve(__dirname, "src/riot/"),
@@ -69,14 +77,10 @@ module.exports = (env) => {
                 ReduxImpl: path.resolve(__dirname, "src/js/redux"),
                 Actions: path.resolve(__dirname, "src/js/actions"),
             },
-            plugins: [
-                PnpWebpackPlugin,
-            ],
+            plugins: [PnpWebpackPlugin],
         },
         resolveLoader: {
-            plugins: [
-                PnpWebpackPlugin.moduleLoader(module),
-            ],
+            plugins: [PnpWebpackPlugin.moduleLoader(module)],
         },
         module: {
             rules: [
@@ -201,16 +205,17 @@ module.exports = (env) => {
                 eslint: {
                     files: ["./src/**/*.ts"],
                 },
-            }),            
+            }),
         ],
     };
 
-    const productionWebpackConfig = env && env.PRODUCTION ? require("./webpack.prod.js") : {};
+    const productionWebpackConfig =
+        env && env.PRODUCTION ? require("./webpack.prod.js") : {};
 
     const config = mergeWithCustomize({
         customizeArray: customizeArray({
-            'resolve.modules': 'prepend'
-        })
+            "resolve.modules": "prepend",
+        }),
     })(
         baseConfig,
         projectConfiguration.WEBPACK_CONFIG,


### PR DESCRIPTION
Our webpack.config file shows its legacy of cut-n-paste.

So to make the changes required for setting everything up for testing clearer.  This is a one-time pas through with `prettier`.