### PR TITLE
Remove aliases in favour of link:s

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,7 @@
     "private": true,
     "types": "dist/types/index.d.ts",
     "ava": {
-        "babel": {
-            "testOptions": {
-                "plugins": [
-                    "babel-plugin-7-webpack-alias"
-                ]
-            }
-        },
+        "babel": true,
         "extensions": [
             "mjs",
             "ts"
@@ -61,7 +55,6 @@
         "@yarnpkg/pnpify": "^2.3.3",
         "ava": "^3.13.0",
         "babel-loader": "^8.1.0",
-        "babel-plugin-7-webpack-alias": "^0.2.1",
         "clean-webpack-plugin": "^3.0.0",
         "css-loader": "^4.2.0",
         "cssnano": "^4.1.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,13 +72,6 @@ module.exports = (env) => {
         resolve: {
             extensions: [".ts", ".js", ".cjs", ".mjs", ".json", ".riot.html"],
             modules: [path.resolve(__dirname, "src")],
-            alias: {
-                RiotTags: path.resolve(__dirname, "src/riot/"),
-                js: path.resolve(__dirname, "src/js"),
-                ReduxImpl: path.resolve(__dirname, "src/js/redux"),
-                Actions: path.resolve(__dirname, "src/js/actions"),
-                ts: path.resolve(__dirname, "src/ts"),
-            },
             plugins: [PnpWebpackPlugin],
         },
         resolveLoader: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4232,17 +4232,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-7-webpack-alias@npm:^0.2.1":
-  version: 0.2.2
-  resolution: "babel-plugin-7-webpack-alias@npm:0.2.2"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.0.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: d4eb519caf2a890e5c001a3e5a0d5e54aeff2b65d9de492c7ee0f545966ce2913a0295b84cc0c5cd6146c182740da25d8f776cbc4e39c96300191c5341a0ae2d
-  languageName: node
-  linkType: hard
-
 "babel-plugin-dynamic-import-node@npm:^2.3.3":
   version: 2.3.3
   resolution: "babel-plugin-dynamic-import-node@npm:2.3.3"
@@ -5058,7 +5047,6 @@ __metadata:
     RiotTags: "link:src/riot/"
     ava: ^3.13.0
     babel-loader: ^8.1.0
-    babel-plugin-7-webpack-alias: ^0.2.1
     babel-polyfill: ^6.26.0
     clean-webpack-plugin: ^3.0.0
     css-loader: ^4.2.0


### PR DESCRIPTION
# Description

`yarn` v2 prefers to use `link:` definitions in the `package.json` `dependencies` instead of using `webpack.config`'s `resolve` `alias` approach.

So just doing things `yarn`'s way means that we can clear out the `alias`es, as well as remove the special `babel` plugin that `ava` requires to handle `alias`es in code referenced by tests.