### PR TITLE
Separate config for JS & TS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,23 @@ Canoe is the shared progressive web app for Catalpa's e-learning projects.
 Canoe is designed to be a pure javascript codebase that can be hosted simply by NGINX or even on a CDN.
 It is dependent on a backend server application that lives in the project contianing it to provide authentication, content and action storing APIs.
 
-## Node and Yarn
+## Javascript Environment
 
-Node 12.18.3
-Yarn 2
+Key Software for Building and Testing
+
+### Environment
+- Node 14.15.1
+
+### Dependency Management
+- Yarn 2.1.1
+
+### Transpiling
+- Typescript 3.8.3
+- Webpack 4.44.1
+- Babel 7.8.4
+
+### Testing
+- Ava 3.13.0
 
 ## Instructions
 

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,4 +1,7 @@
-module.exports = {
+/** This babel config is for Javascript only (js|cjs|mjs),
+ * for Typescript see the babel settings in the webpack config */
+
+ module.exports = {
     presets: [
         [
             "@babel/preset-env",
@@ -8,14 +11,13 @@ module.exports = {
                 useBuiltIns: "usage",
             },
         ],
-        "@babel/preset-typescript",
     ],
     plugins: [
         [
             "@babel/plugin-transform-runtime",
             {
                 regenerator: true,
-            }
-        ]
+            },
+        ],
     ],
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "devDependencies": {
         "@ava/babel": "^1.0.1",
         "@babel/core": "^7.12.9",
+        "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-transform-runtime": "^7.8.3",
         "@babel/preset-env": "^7.12.7",
         "@babel/preset-typescript": "^7.12.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["dom", "dom.iterable", "esnext"], /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -125,17 +125,37 @@ module.exports = (env) => {
                     },
                 },
                 {
-                    test: /\.(js|mjs|ts)$/,
+                    test: /\.(js|cjs|mjs)$/,
+                    exclude: [/node_modules/, "/src/**/tests/**/*"],
+                    use: {
+                        loader: "babel-loader",
+                    },
+                },
+                {
+                    test: /\.(ts)$/,
                     exclude: [/node_modules/, "/src/**/tests/**/*"],
                     use: {
                         loader: "babel-loader",
                         options: {
                             presets: [
-                                "@babel/preset-env",
                                 "@babel/preset-typescript",
+                                "@babel/preset-env",
                             ],
-                            plugins: ["@babel/plugin-transform-runtime"],
-                        },
+                            plugins: [
+                                [
+                                    "@babel/plugin-transform-runtime",
+                                    {
+                                        regenerator: true,
+                                    },
+                                ],
+                                [
+                                    "@babel/plugin-proposal-class-properties",
+                                    {
+                                        loose: true,
+                                    },
+                                ],
+                            ],
+                        },                      
                     },
                 },
             ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5027,6 +5027,7 @@ __metadata:
   dependencies:
     "@ava/babel": ^1.0.1
     "@babel/core": ^7.12.9
+    "@babel/plugin-proposal-class-properties": ^7.12.1
     "@babel/plugin-transform-runtime": ^7.8.3
     "@babel/preset-env": ^7.12.7
     "@babel/preset-typescript": ^7.12.7


### PR DESCRIPTION
This cleans up the babel and webpack configs for building/testing JS and TS.

This enables the following:

- Lets us use current TS and JS language features
- Fixes the minimum ECMA version that we'll let Typescript be transpiled to (ES2015)
- Ensures that we can independently improve the babel+webpack transpilation without getting the Service Worker JS code screwed up (because it needs some love...)

Also tweaks up the readme to identify key versions for the build and test environment - note the jump in Node versions which enables simpler webpack and babel syntaxes and easier transpilation.