### PR TITLE
Fix sync button only showing in Appelflap

### DIFF
--- a/src/riot/Components/BottomMenu.riot.html
+++ b/src/riot/Components/BottomMenu.riot.html
@@ -9,7 +9,7 @@
             class="resources-icon { props.contentType === 'resources' ? 'active' : ''}"
             href="#resources"
         ></a>
-        <a
+        <a if="{shouldShowSync()}"
             class="resources-icon { props.contentType === 'sync' ? 'active' : ''}"
             href="#sync"
         ></a>


### PR DESCRIPTION
The sync button was only supposed to show up, if canoe is hosted by Appelflap - but somehow that if statement in the riot tag got 'eliminated'.

This puts in back ...

Testing
run this in a browser - no sync button
run this on a mobile (launched via `adb` / `android studio`) - sync button