### PR TITLE
Add support for credentials provided by appelflap

### DIFF
--- a/src/ts/AppelflapConnect.ts
+++ b/src/ts/AppelflapConnect.ts
@@ -16,13 +16,11 @@ import { AF_LOCALHOSTURI, APPELFLAPCOMMANDS, AppelflapPortNo } from "js/RoutingA
 /* eslint-enable prettier/prettier */
 
 export class AppelflapConnect {
-    #authHeader = "Not set";
-
+    /** Get the Authorisation Header details that Appelflap requires
+     * @remarks See: https://github.com/catalpainternational/appelflap/blob/7a4072f8b914748563333238bb1a49ea527480bd/docs/API/determining-endpoint.md for more info
+     * @returns The auth header as `Basic btoaEncodedStuff` or 'None' if the credentials are not available
+     */
     get authHeader(): string {
-        if (this.#authHeader !== "Not set") {
-            return this.#authHeader;
-        }
-
         const credentialsExtract = (prefix: string) => {
             const rex = RegExp(`^${prefix}-[a-z]{5}$`);
             const match = navigator.languages.filter((word) =>
@@ -33,11 +31,9 @@ export class AppelflapConnect {
         };
 
         const creds = ["ecu", "ecp"].map(credentialsExtract);
-        this.#authHeader = !creds.every(Boolean)
+        return !creds.every(Boolean)
             ? "None"
-            : `Basic: ${btoa(creds.join(":"))}`;
-
-        return this.#authHeader;
+            : `Basic ${btoa(creds.join(":"))}`;
     }
 
     private appelflapFetch = async (


### PR DESCRIPTION
Closes #354 

This breaks out the 'use the special credentials provided by appelFlap' piece of work into its own :pr:
(It was in Manifest_Handling, but it's not directly related to Manifest Handling).

# Description
This includes the code to look for the `ecu` and `ecp` languages in Navigator, which are put there by Appelflap, and then process and use those codes to create an `Authorization` header for Canoe as it communicates with Appelflap.

# Testing
This has to be tested on device or emulator, running the latest version of Appelflap, and using the Firefox remote debugging so that you can set a breakpoint on this code and watch it step through whenever Canoe sends a request to Appelflap, which it will do at start up or restart. 
