### PR TITLE
And back out again too

### DIFF
--- a/src/ts/CertChain.ts
+++ b/src/ts/CertChain.ts
@@ -26,9 +26,11 @@ export class CertChain {
             this.#packageCert = await this.GetPackageCertificateFromAppelflap();
             if (!this.#packageCert?.isCertSigned) {
                 const lastError = await this.PostPackageCertificateForSigning();
-                console.error(`lastError: ${lastError}`);
                 if (!lastError && this.#packageCert) {
                     const result = await this.PostPackageCertificateToAppelflap();
+                    if (!result) {
+                        this.#packageCert = await this.GetPackageCertificateFromAppelflap();
+                    }
                 }
             }
         } catch (e) {


### PR DESCRIPTION
# Description

Actually the getting the signed cert back into Appelflap is already done. This :pr: is about getting the signed cert back out again at the end of the whole process.

## Remarks
Please note that Canoe cannot recognise that a cert has been signed until the :pr:  https://github.com/catalpainternational/appelflap/pull/40 has been marged into appelflap