### PR TITLE
Better certchain handling, reduces transpiler warnings

### DIFF
--- a/src/ts/StartUp.ts
+++ b/src/ts/StartUp.ts
@@ -36,8 +36,16 @@ export const InitialiseCertChain = async (): Promise<void> => {
     if (afc && !gt.certChain) {
         try {
             gt.certChain = new CertChain(afc);
-            const hasCert = await gt.certChain.initialise();
-            const packageCert = gt.certChain.packageCertificate;
+            const hasCert = await (gt.certChain as CertChain).initialise();
+            if (!hasCert) {
+                throw new Error(
+                    "Publishing certificate chain could not be initialised. \
+                    The certificate endpoint may not be working, \
+                    Canoe is not running within Appelflap (the mobile host), \
+                    the user is not logged in \
+                    or the user may not have the correct permissions."
+                );
+            }
         } catch (e) {
             // No signed cert - change this to a proper message, if that is appropriate
             console.info(e);


### PR DESCRIPTION
# Description

The existing certificate chain initialisation process works, but it raises too many transpiler warnings.

This fix doesn't get rid of all of them, but it does give us some more consistent behaviour.

The warning it doesn't fix is where we need to decide if will report cert chain issues to the user (and/or logging), and how. 