### PR TITLE
Page is publishable first step

### DIFF
--- a/src/js/SiteDownloader.js
+++ b/src/js/SiteDownloader.js
@@ -15,8 +15,8 @@ import { getAuthenticationToken } from "js/AuthenticationUtilities";
 import { storeWagtailPage } from "ReduxImpl/Interface";
 import { BACKEND_BASE_URL } from "js/urls";
 import { getImageRequest, getPageRequest } from "./Fetch";
+import { PAGES_CACHE_NAME } from "ts/Constants";
 
-const PAGES_CACHE = "pages-cache";
 const IMAGES_CACHE = "images-cache";
 
 const trimDomain = (urlWithDomain) => urlWithDomain.replace(/^.*\/\/[^\/]+/, "");
@@ -48,7 +48,7 @@ const cacheAllUrls = async (cacheName, paths, getRequest = (path) => path) => {
 };
 
 const addCachedPagesToRedux = async () => {
-    const pagesCache = await caches.open(PAGES_CACHE);
+    const pagesCache = await caches.open(PAGES_CACHE_NAME);
     const cacheKeys = await pagesCache.keys();
 
     for (const cacheKeyRequest of cacheKeys) {
@@ -69,7 +69,7 @@ export default class SiteDownloader {
         const manifestsPagePaths = new Set([...homePagePaths, ...Object.values(manifest.pages)]);
         const manifestsImagesPaths = new Set(getImagePaths(manifest.images));
 
-        const cachedPagePaths = await getCachedPathsAndDeleteCruft(PAGES_CACHE, manifestsPagePaths);
+        const cachedPagePaths = await getCachedPathsAndDeleteCruft(PAGES_CACHE_NAME, manifestsPagePaths);
         const cachedImagePaths = await getCachedPathsAndDeleteCruft(
             IMAGES_CACHE,
             manifestsImagesPaths
@@ -82,7 +82,7 @@ export default class SiteDownloader {
             dispatchToastEvent(gettext("Site is downloading."));
         }
 
-        // await cacheAllUrls(PAGES_CACHE, pagesToFetch, getPageRequest);
+        // await cacheAllUrls(PAGES_CACHE_NAME, pagesToFetch, getPageRequest);
         // await cacheAllUrls(IMAGES_CACHE, imagesToFetch, getImageRequest);
 
         for (const pagePath of pagesToFetch) {

--- a/src/riot/CacheDisplay.riot.html
+++ b/src/riot/CacheDisplay.riot.html
@@ -42,7 +42,7 @@
 
     <script>
         import { getCachesInfo, storageQuota } from "js/cacheManager/cacheManager";
-        import { MANIFEST_CACHE_NAME } from "ts/Constants";
+        import { MANIFEST_CACHE_NAME, PAGES_CACHE_NAME } from "ts/Constants";
 
         import prettyBytes from "pretty-bytes";
 
@@ -67,7 +67,7 @@
                         case MANIFEST_CACHE_NAME:
                             cacheSummary['App'] += q.size;
                             break;
-                        case 'pages-cache':
+                        case PAGES_CACHE_NAME:
                             cacheSummary['Pages'] += q.size;
                             break;
                         case 'images-cache':

--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -103,7 +103,7 @@
 
                     // try getting a page
                     const aPage = await manifest.getPageData("/site/home", "en");
-                    this.update({ page: JSON.stringify(page.data) });
+                    this.update({ page: JSON.stringify(aPage.data) });
                 }
             }
         }

--- a/src/sw.js
+++ b/src/sw.js
@@ -13,7 +13,7 @@ import { precacheAndRoute } from "workbox-precaching";
 
 precacheAndRoute(self.__WB_MANIFEST);
 
-import { MANIFEST_CACHE_NAME } from "ts/Constants";
+import { MANIFEST_CACHE_NAME, PAGES_CACHE_NAME } from "ts/Constants";
 import { ROUTES_FOR_REGISTRATION } from "js/urls";
 import { buildAppelflapRoutes } from "js/RoutingAppelflap";
 
@@ -35,7 +35,7 @@ registerRoute(
 registerRoute(
     new RegExp(ROUTES_FOR_REGISTRATION.pagesv2),
     new CacheFirst({
-        cacheName: "pages-cache",
+        cacheName: PAGES_CACHE_NAME,
     })
 );
 

--- a/src/ts/CacheHandler.ts
+++ b/src/ts/CacheHandler.ts
@@ -1,12 +1,14 @@
 export class CacheHandler {
     /** Try to match a URL in the SW cache, ignore any query params in the url */
     match = async (
-        url: string,
-        cacheName: string
+        cacheName: string,
+        url: string
     ): Promise<Response | undefined> => {
         return await caches.match(url, {
             cacheName: cacheName,
             ignoreSearch: true,
+            ignoreMethod: true,
+            ignoreVary: true,
         });
     };
 }

--- a/src/ts/CacheHandler.ts
+++ b/src/ts/CacheHandler.ts
@@ -1,0 +1,12 @@
+export class CacheHandler {
+    #cache: Cache;
+
+    constructor() {
+        this.#cache = new Cache();
+    }
+
+    /** Try to match a URL in the SW cache, ignore any query params in the url */
+    match = async (url: string): Promise<Response | undefined> => {
+        return await this.#cache.match(url, { ignoreSearch: true });
+    };
+}

--- a/src/ts/CacheHandler.ts
+++ b/src/ts/CacheHandler.ts
@@ -1,12 +1,12 @@
 export class CacheHandler {
-    #cache: Cache;
-
-    constructor() {
-        this.#cache = new Cache();
-    }
-
     /** Try to match a URL in the SW cache, ignore any query params in the url */
-    match = async (url: string): Promise<Response | undefined> => {
-        return await this.#cache.match(url, { ignoreSearch: true });
+    match = async (
+        url: string,
+        cacheName: string
+    ): Promise<Response | undefined> => {
+        return await caches.match(url, {
+            cacheName: cacheName,
+            ignoreSearch: true,
+        });
     };
 }

--- a/src/ts/Constants.ts
+++ b/src/ts/Constants.ts
@@ -1,4 +1,5 @@
 /* A place to define various magic strings etc. that do not belong in urls.js */
 
 export const MANIFEST_CACHE_NAME = "manifest-cache";
+export const PAGES_CACHE_NAME = "pages-cache";
 export const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -72,7 +72,7 @@ export class Manifest implements TManifest {
     }
 
     async initialiseByRequest(): Promise<void> {
-        const resp = await fetch(`${ROUTES_FOR_REGISTRATION.manifest}/v1`, {
+        const resp = await fetch(`${ROUTES_FOR_REGISTRATION.manifest}`, {
             method: "GET",
             headers: {
                 "Content-Type": "application/json",
@@ -125,18 +125,18 @@ export class Manifest implements TManifest {
                 return false;
             }
 
-            // We could get false matches here, needs more work
-            if (page.loc_hash.indexOf(locationHash) === -1) {
+            // Exact match or match with languageCode at the end
+            if (
+                page.loc_hash !== locationHash &&
+                page.loc_hash !== `${locationHash}-${languageCode}`
+            ) {
                 return false;
             }
 
             // Check the language matches
-            if (languageCode === "tet" || languageCode === "tdt") {
-                // Check for both 'tet' and 'tdt' together
-                // We should be using 'tdt', but for historical reasons we usually use 'tet'
-                // so we're treating them the same
-                return page.language === "tet" || page.language === "tdt";
-            }
+            // Note: We should be using 'tdt' for Tetun Dili,
+            // but for historical reasons we usually use 'tet'
+            // This test doesn't allow for that
             return page.language.indexOf(languageCode) === 0;
         });
 

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -157,6 +157,16 @@ export class Manifest implements TManifest {
         return Promise.reject(false);
     }
 
+    async getPage(data: TWagtailPageData): Promise<TWagtailPage> {
+        const manifestPage = new Page(data);
+        const pageFilled = await manifestPage.initialiseByRequest();
+        if (pageFilled) {
+            return manifestPage;
+        }
+
+        return Promise.reject(false);
+    }
+
     async getPageData(
         locationHash: string,
         languageCode: string
@@ -167,7 +177,7 @@ export class Manifest implements TManifest {
         );
 
         if (pageManifestData) {
-            return await this.getPageByUrl(pageManifestData.api_url);
+            return await this.getPage(pageManifestData);
         }
 
         return Promise.reject(false);

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -14,6 +14,7 @@ import { getAuthenticationToken } from "js/AuthenticationUtilities";
 import { BACKEND_BASE_URL } from "js/urls";
 
 export class Page implements TWagtailPage {
+    #cache!: Cache;
     data!: TWagtailPageData;
     #status!: string;
 
@@ -151,13 +152,15 @@ export class Page implements TWagtailPage {
     }
 
     async initialiseFromCache(): Promise<void> {
+        this.#cache = await caches.open(PAGES_CACHE_NAME);
+
         if (this.api_url) {
             this.#status = "loading:cache";
-            const cacheHandler = new CacheHandler();
-            const resp = await cacheHandler.match(
-                PAGES_CACHE_NAME,
-                this.fullUrl
-            );
+            const resp = await this.#cache.match(this.fullUrl, {
+                ignoreSearch: true,
+                ignoreMethod: true,
+                ignoreVary: true,
+            });
             if (resp) {
                 await this.initialiseFromResponse(resp);
                 this.#status = "ready:cache";

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {
     TAssetEntry,
+    TPage,
     TWagtailPage,
     TWagtailPageData,
 } from "ts/Types/ManifestTypes";
@@ -13,12 +14,18 @@ import { BACKEND_BASE_URL } from "js/urls";
 export class Page implements TWagtailPage {
     data!: TWagtailPageData;
 
-    constructor(apiUrl?: string) {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    constructor(opts?: any) {
         if (!this.data) {
             this.data = Page.emptyItem;
         }
-        if (apiUrl) {
-            this.data.api_url = apiUrl;
+        if (typeof opts === "undefined") {
+            return;
+        }
+        if (typeof opts === "string") {
+            this.data.api_url = opts;
+        } else if (opts instanceof Page) {
+            this.clone(opts);
         }
         this.initialiseFromStore();
     }
@@ -56,11 +63,15 @@ export class Page implements TWagtailPage {
     }
 
     /** From old wagtail page definition */
-    get meta(): Record<string, any> {
-        return this.data?.meta || "";
+    get meta(): Record<string, any> | undefined {
+        return this.data?.meta;
     }
 
     get pageId(): string {
+        if (this.data.id) {
+            return this.data.id.toString();
+        }
+
         const url = this.api_url.split("/").filter((token) => token);
         return url.length ? url[url.length - 1] : "";
     }
@@ -106,6 +117,10 @@ export class Page implements TWagtailPage {
             isAvailableOffline: false,
             isPublishable: false,
         };
+    }
+
+    clone(data: TPage): void {
+        this.data = JSON.parse(JSON.stringify(data));
     }
 
     initialiseFromStore(): void {

--- a/src/ts/Types/ManifestTypes.ts
+++ b/src/ts/Types/ManifestTypes.ts
@@ -19,6 +19,10 @@ export type TPageData = {
 export type TPage = TPageData & TManifestItemState;
 
 export type TWagtailPageData = {
+    id?: number;
+    meta?: Record<string, any>;
+    title?: string;
+    data?: Record<string, any>;
     [x: string]: any;
 } & TPageData;
 


### PR DESCRIPTION
# Description

Actually get a page back out of the cache if it is in there.

A simple `status` value has been added to `Page` to keep track of its overall initialisation process.  This will be cleaned up later, once we better understand the state-machine like requirements of setting up a page and getting to `isPublishable`.

## Note
The deprecated `SiteDownloader.js` and `CacheDisplay.riot.html` have both been updated with the newly defined `PAGES_CACHE_NAME` constant. This is only about avoided potential weird technical debt until we actually get rid of these two.  