### PR TITLE
Storage container page and asset

### DIFF
--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -7,7 +7,6 @@ import { getBrowser } from "ts/PlatformDetection";
 
 // See ts/Typings for the type definitions for these imports
 import { BACKEND_BASE_URL } from "js/urls";
-import { MissingImageError } from "js/Errors";
 
 export class Asset extends PublishableItem<TAssetEntry> {
     #blob?: Blob;
@@ -45,15 +44,16 @@ export class Asset extends PublishableItem<TAssetEntry> {
     }
 
     get manifestData(): TAssetEntry {
-        const parentPage = this.manifest?.pages[this.id];
+        const parentPage = this.manifest?.pages[this.pageId];
         if (!parentPage) {
             return this.emptyItem;
         }
 
-        return (
-            parentPage?.assets.find((asset) => asset.id === this.id) ||
-            this.emptyItem
+        const asset = parentPage?.assets.find(
+            (asset) => asset.id.toString() === this.id.toString()
         );
+
+        return asset || this.emptyItem;
     }
 
     /** The url of the rendition that is most relevant to this platform */
@@ -62,9 +62,9 @@ export class Asset extends PublishableItem<TAssetEntry> {
         const rendition = this.renditions[renditionType];
 
         if (!rendition) {
-            const error = `${renditionType} image doesn't exist.
-            Renditions: ${JSON.stringify(this.renditions)}`;
-            throw new MissingImageError(error);
+            // Do NOT throw a MissingImageError here
+            // because it will silently screw up the rest of the asset instantiation
+            return "";
         }
 
         return rendition;

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -259,7 +259,7 @@ export class Page extends PublishableItem<TWagtailPageData> {
         const pageAsset = new Asset(
             this.manifest,
             this.id,
-            asset.id,
+            asset.id.toString(),
             this.cacheKey
         );
         const assetFilled = await pageAsset.initialiseFromCache();

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -233,7 +233,7 @@ export class Page extends PublishableItem<TWagtailPageData> {
     }
 
     get cacheKey(): string {
-        return this.fullUrl;
+        return this.storage_container;
     }
 
     async initialiseFromResponse(resp: Response): Promise<boolean> {
@@ -254,13 +254,14 @@ export class Page extends PublishableItem<TWagtailPageData> {
     private assetInitialised = (asset: TAssetEntry): boolean =>
         asset.isValid || false;
 
-    async loadAsset(asset: TAssetEntryData, index: number): Promise<Asset> {
-        // The asset's parentUrl is the same as the cache name
-        // (which is the same as this page's full url)
-        // See `cacheKey` above
-        asset.parentUrl = this.fullUrl;
-        const pageAsset = new Asset(this.manifest, this.id, index);
-        pageAsset.parentUrl = this.fullUrl;
+    async loadAsset(asset: TAssetEntryData): Promise<Asset> {
+        // The asset's cache name is the same as the Page's cache name
+        const pageAsset = new Asset(
+            this.manifest,
+            this.id,
+            asset.id,
+            this.cacheKey
+        );
         const assetFilled = await pageAsset.initialiseFromCache();
 
         if (assetFilled) {
@@ -285,7 +286,7 @@ export class Page extends PublishableItem<TWagtailPageData> {
         this.#assets = [];
         for (let ix = 0; ix < this.manifestAssets.length; ix++) {
             try {
-                const asset = await this.loadAsset(this.manifestAssets[ix], ix);
+                const asset = await this.loadAsset(this.manifestAssets[ix]);
                 this.#assets.push(asset);
             } catch {
                 // Could not fill the asset
@@ -294,18 +295,18 @@ export class Page extends PublishableItem<TWagtailPageData> {
     }
 
     getAssetsByIdAndType(
-        id: number,
+        id: number | string,
         assetType: string
     ): TAssetEntry | undefined {
         const assets = this.manifestData.assets;
         return assets.find((a: TAssetEntry) => {
-            return a.id === id && a.type === assetType;
+            return a.id === id.toString() && a.type === assetType;
         });
     }
 
-    PETEgetImageRenditions = (id: number): TAssetEntry | undefined =>
+    PETEgetImageRenditions = (id: number | string): TAssetEntry | undefined =>
         this.getAssetsByIdAndType(id, "image");
 
-    PETEgetMediaRenditions = (id: number): TAssetEntry | undefined =>
+    PETEgetMediaRenditions = (id: number | string): TAssetEntry | undefined =>
         this.getAssetsByIdAndType(id, "media");
 }

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -140,8 +140,11 @@ export abstract class PublishableItem<T extends TManifestItem>
     private get NewRequestObject(): Request {
         const headers: any = {
             "Content-Type": this.contentType,
-            Authorization: `JWT ${getAuthenticationToken()}`,
         };
+        const token = getAuthenticationToken();
+        if (token) {
+            headers["Authorization"] = `JWT ${token}`;
+        }
 
         const reqInit: any = {
             cache: "no-cache",

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -192,6 +192,10 @@ export abstract class PublishableItem<T extends TManifestItem>
     private async GetRequestObject(): Promise<Request | undefined> {
         const cacheOpen = await this.accessCache();
 
+        if (!this.fullUrl) {
+            // "The full url could not be determined for this item, it is not retrievable";
+            return Promise.resolve(undefined);
+        }
         if (this.#requestObject && this.#requestObject.url === this.fullUrl) {
             this.CleanRequestObject(this.#requestObject);
             return this.#requestObject;
@@ -243,8 +247,14 @@ export abstract class PublishableItem<T extends TManifestItem>
         if (!reqObj) {
             this.source = "unset";
             this.status = "prepped";
-            reqObj = this.NewRequestObject;
-            this.CleanRequestObject(reqObj);
+            if (this.fullUrl) {
+                reqObj = this.NewRequestObject;
+                this.CleanRequestObject(reqObj);
+            } else {
+                // Without a fullUrl we cannot retrieve this item
+                // from either the cache or the network
+                return false;
+            }
         }
 
         this.source = "cache";

--- a/src/ts/Types/ManifestTypes.ts
+++ b/src/ts/Types/ManifestTypes.ts
@@ -26,7 +26,7 @@ export type TPageData = {
 export type TPage = TPageData & TManifestItemState;
 
 export type TWagtailPageData = {
-    id?: number;
+    id?: string;
     meta?: Record<string, any>;
     data?: Record<string, any>;
 } & TPageData;
@@ -34,6 +34,7 @@ export type TWagtailPageData = {
 export type TWagtailPage = TWagtailPageData & TManifestItemState;
 
 export type TAssetEntryData = {
+    id: string;
     type: string;
     renditions: Record<string, string>;
 } & TManifestItem;

--- a/src/ts/tests/fakeManifest.ts
+++ b/src/ts/tests/fakeManifest.ts
@@ -50,6 +50,7 @@ function buildFakeAssetEntry(type: string, asset_name: string): TAssetEntry {
     });
 
     return {
+        id: "",
         type: type,
         renditions: renditions,
         api_url: "",


### PR DESCRIPTION
# Description

This makes a set of little tweaks to get both `Page` and `Asset` to use the `Page`'s storage_location for their cache name (as originally intended).

It also corrects how `Page` and `Asset` are connected using the internal `Id` within the `Asset`.  And it allows for the `Asset`'s `Id` to be a `string` or a `number` in the original manifest data.