### PR TITLE
382 login screen visual QA

### DIFF
--- a/src/riot/Components/LoadingDots.riot.html
+++ b/src/riot/Components/LoadingDots.riot.html
@@ -1,7 +1,3 @@
 <LoadingDots>
-    <div class="spinner">
-        <div class="bounce-1 {props.extrastyleclasses}"></div>
-        <div class="bounce-2 {props.extrastyleclasses}"></div>
-        <div class="bounce-3 {props.extrastyleclasses}"></div>
-    </div>
+    <div class="loader {props.extrastyleclasses}"></div>
 </LoadingDots>

--- a/src/scss/_buttons.scss
+++ b/src/scss/_buttons.scss
@@ -27,6 +27,11 @@
         LoadingDots {
             top: 0;
             position: absolute;
+            margin-left: 12px;
+
+            & > .loader {
+              margin: 1em auto;
+            }
         }
     }
 }

--- a/src/scss/_images.scss
+++ b/src/scss/_images.scss
@@ -22,7 +22,7 @@
 
 .site-logo {
     @include unmaskable-icons-shared("~img/site_logo.svg", contain);
-    height: 30px;
+    height: 36px;
     width: 87px;
 }
 
@@ -145,8 +145,8 @@
 
 .login-image {
     @include unmaskable-icons-shared("~img/login_image.svg", contain);
-    width: 125px;
-    height: 125px;
+    width: 130px;
+    height: 130px;
 }
 
 .eye {

--- a/src/scss/_loading.scss
+++ b/src/scss/_loading.scss
@@ -1,7 +1,7 @@
 LoadingDots {
   .loader {
-    margin: 1em;
-    display: inline-block;
+    margin: 2em auto;
+    text-align: center;
     width: 20px;
     height: 20px;
     border-radius: 50%;

--- a/src/scss/_loading.scss
+++ b/src/scss/_loading.scss
@@ -1,65 +1,29 @@
 LoadingDots {
-    .spinner {
-        margin: 1em auto;
-        width: 100px;
-        text-align: center;
+  .loader {
+    margin: 1em;
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border-width: 0px;
+    border-right: 3px solid transparent;
+    animation: circ-anim 1.2s linear infinite;
+
+    &.dark {
+      border-top: 3px solid $gray-2;
     }
 
-    .spinner > div {
-        width: 17px;
-        height: 17px;
-        margin-right: 7px;
-        margin-left: 7px;
-
-        border-radius: 100%;
-        display: inline-block;
-        -webkit-animation: bounceDelay 1.4s infinite ease-in-out both;
-        animation: bounceDelay 1.4s infinite ease-in-out both;
-
-        &.dark {
-            background-color: $gray-2;
-        }
-
-        &.light {
-            background-color: $gray-7;
-        }
+    &.light {
+      border-top: 3px solid $gray-7;
     }
+  }
 
-    .app {
-        margin-top: 7em;
+  @keyframes circ-anim {
+    from {
+      transform: rotate(0);
     }
-
-    .spinner .bounce-1 {
-        -webkit-animation-delay: -0.32s;
-        animation-delay: -0.32s;
+    to {
+      transform: rotate(360deg);
     }
-
-    .spinner .bounce-2 {
-        -webkit-animation-delay: -0.16s;
-        animation-delay: -0.16s;
-    }
-
-    @-webkit-keyframes bounceDelay {
-        0%,
-        80%,
-        100% {
-            -webkit-transform: scale(0);
-        }
-        40% {
-            -webkit-transform: scale(1);
-        }
-    }
-
-    @keyframes bounceDelay {
-        0%,
-        80%,
-        100% {
-            -webkit-transform: scale(0);
-            transform: scale(0);
-        }
-        40% {
-            -webkit-transform: scale(1);
-            transform: scale(1);
-        }
-    }
+  }
 }

--- a/src/scss/_login.scss
+++ b/src/scss/_login.scss
@@ -1,5 +1,5 @@
 Login .modal-background {
-    $content-width: 18.75em;
+    $content-width: calc(100vw - 40px);
 
     min-height: 100vh;
     flex-direction: column;
@@ -12,8 +12,8 @@ Login .modal-background {
         display: flex;
         align-items: center;
         flex-direction: column;
-        height: 300px;
-        margin-bottom: 20px;
+        height: 270px;
+        margin-bottom: 30px;
 
         span {
             margin-bottom: 20px;
@@ -66,7 +66,7 @@ Login .modal-background {
             flex-direction: column;
             margin-bottom: 15px;
             border-radius: 5px;
-            padding: 5px 15px;
+            padding: 0 15px;
             display: flex;
             background-color: $white;
             box-shadow: inset 0 2px 3px 0 rgba(42, 57, 66, 0.1);
@@ -138,7 +138,7 @@ Login .modal-background {
 
         max-width: $content-width;
         width: 100%;
-        margin-top: 20px;
+        margin-top: 30px;
 
         a {
             font-size: 0.875em;

--- a/src/scss/_login.scss
+++ b/src/scss/_login.scss
@@ -21,6 +21,9 @@ Login .modal-background {
 
         h4 {
             margin: 0 auto 10px;
+            color: $gray-1;
+            font-weight: 400;
+            font-size: 1.3em;
         }
     }
 

--- a/src/scss/_login.scss
+++ b/src/scss/_login.scss
@@ -76,7 +76,7 @@ Login .modal-background {
 
             label {
                 left: 0;
-                top: 30%;
+                top: 25%;
                 margin: 0;
                 padding-left: 15px;
                 position: absolute;
@@ -95,15 +95,15 @@ Login .modal-background {
                 border: 1px solid $gray-4;
 
                 label {
-                    font-size: 0.75em;
-                    top: 5%;
+                    font-size: 0.7em;
+                    top: 10%;
                 }
             }
 
             &.is-filled {
                 label {
-                    font-size: 0.75em;
-                    top: 5%;
+                    font-size: 0.7em;
+                    top: 10%;
                 }
             }
         }
@@ -154,6 +154,7 @@ Login .modal-background {
         border: none;
         padding-top: 15px;
         background-color: unset;
+        font-size: 16px;
 
         &:focus {
             outline: none;

--- a/src/scss/_login.scss
+++ b/src/scss/_login.scss
@@ -32,8 +32,8 @@ Login .modal-background {
     }
 
     LoginForm {
-        max-width: $content-width;
-        width: 100%;
+        max-width: $tablet;
+        width: $content-width;
         display: flex;
         justify-content: center;
     }
@@ -139,8 +139,8 @@ Login .modal-background {
     .extra-button-space {
         display: flex;
 
-        max-width: $content-width;
-        width: 100%;
+        max-width: $tablet;
+        width: $content-width;
         margin-top: 30px;
 
         a {

--- a/src/scss/_login.scss
+++ b/src/scss/_login.scss
@@ -65,7 +65,7 @@ Login .modal-background {
         div.form-group {
             flex-direction: column;
             margin-bottom: 15px;
-            border-radius: 5px;
+            border-radius: 3px;
             padding: 0 15px;
             display: flex;
             background-color: $white;

--- a/src/scss/_login.scss
+++ b/src/scss/_login.scss
@@ -157,7 +157,6 @@ Login .modal-background {
         border: none;
         padding-top: 15px;
         background-color: unset;
-        font-size: 16px;
 
         &:focus {
             outline: none;

--- a/src/scss/_top_menu.scss
+++ b/src/scss/_top_menu.scss
@@ -35,8 +35,9 @@ TopMenu {
 
     h4 {
         text-align: center;
-        color: $gray-3;
-        font-weight: 200;
+        color: $gray-1;
+        font-weight: 400;
+        font-size: 20px;
     }
 
     span {

--- a/src/scss/_top_menu.scss
+++ b/src/scss/_top_menu.scss
@@ -35,9 +35,8 @@ TopMenu {
 
     h4 {
         text-align: center;
-        color: $gray-1;
-        font-weight: 400;
-        font-size: 20px;
+        color: $gray-3;
+        font-weight: 200;
     }
 
     span {

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -94,6 +94,10 @@ input {
     font-weight: 300;
 }
 
+input[type="text"] {
+  font-size: 1em;
+}
+
 ul,
 ol {
     font-family: $app-typography;


### PR DESCRIPTION
#### Addresses feedback in issue #382:
- logo size in header - increased slightly
- login page illustration size - increased slightly
- 'login' title size increased, colour changed
- made the gutter size consistent across screen widths, applied to inputs
- padding for input label
- decreased the height of input
- added margin to the top of the 'forgot my password' button
- updated the loader from the three dots to a simple spinner

#### Remaining work/questions for design:
- Andy asked for the focus state on the inputs, but I haven't been able to find an example of a focused input in the designs
- Andy also asked for a tapped interaction state on the button, but again I haven't been able to find an example of this in the designs

I'm happy to take creative license here, but also happy to wait until Andy is back to clarify these requests.


![Screen Shot 2021-02-09 at 3 11 18 pm](https://user-images.githubusercontent.com/12974326/107317388-ad77c380-6aee-11eb-851b-32a9e9771d73.png)
![Screen Shot 2021-02-09 at 3 11 41 pm](https://user-images.githubusercontent.com/12974326/107317394-afda1d80-6aee-11eb-96d4-7c02f11af0bb.png)
![Screen Shot 2021-02-09 at 3 12 21 pm](https://user-images.githubusercontent.com/12974326/107317397-b072b400-6aee-11eb-8a89-dd1ab6c7a703.png)
