### PR TITLE
Fix filter functionality

### DIFF
--- a/src/riot/Components/TagList.riot.html
+++ b/src/riot/Components/TagList.riot.html
@@ -1,10 +1,10 @@
 <TagList>
     <div class="tag-container">
-        <a  
+        <a
             each="{tag in props.tags}"
-            class="tag {props.selectedTags && props.selectedTags.includes(tag) ? 'selected' : ''}" 
+            class="tag {props.selectedTags && props.selectedTags.includes(tag) ? 'selected' : ''}"
             onclick="{e => { 
-                props.onTagClick(e.srcElement.innerText, false)
+                props.onTagClick(e.srcElement.innerText.toLowerCase(), false)
             }}"
         >
             <p>{tag}</p>

--- a/src/riot/Screens/Resources.riot.html
+++ b/src/riot/Screens/Resources.riot.html
@@ -60,7 +60,7 @@
                 card: Card,
                 searchbar: SearchBar,
                 loadingdots: LoadingDots,
-                topmenu: TopMenu
+                topmenu: TopMenu,
             },
 
             TRANSLATIONS: {
@@ -89,9 +89,9 @@
 
                 const filter = urlParams.getAll("filter");
                 if (filter.length > 0) {
-                    for (var i = 0; i < filter.length; ++i) {
-                        if (listOfAllTags.includes(filter[i])) {
-                            this.onTagClick(decodeURIComponent(filter[i]), true);
+                    for (const tag of filter) {
+                        if (listOfAllTags.includes(tag)) {
+                            this.onTagClick(decodeURIComponent(tag), true);
                         }
                     }
                 }
@@ -116,8 +116,8 @@
                     urlParams.delete("filter");
 
                     if (this.state.selectedTags.length > 0) {
-                        for (var i = 0; i < this.state.selectedTags.length; ++i) {
-                            const pendingTag = this.state.selectedTags[i].toLowerCase();
+                        for (const tag of this.state.selectedTags) {
+                            const pendingTag = tag.toLowerCase();
                             urlParams.append("filter", pendingTag);
                         }
                     }


### PR DESCRIPTION
I broke tag filters on Resources and All Courses with the [`text-transform`here](https://github.com/catalpainternational/canoe/pull/412/files#diff-badc08e0d4088890921a82c58d02993223350fec8eb22b45f8cfea92868689c4R20) because the tag value came from the `srcElement` in `TagList.riot.html`. 