### PR TITLE
Temporary Preview fix

### DIFF
--- a/src/js/Fetch.js
+++ b/src/js/Fetch.js
@@ -51,3 +51,18 @@ export async function token_authed_fetch(url) {
     }
     return pagesResponseJSON;
 }
+
+export async function unauthed_fetch(url) {
+    const response = await fetch_and_denote_unauthenticatedness(url);
+
+    if (!response.ok) {
+        throw new APIMissingPageError(`fetch("${url}") responded with a ${response.status}`);
+    }
+
+    const pagesResponseJSON = await response.json();
+
+    if (pagesResponseJSON.items) {
+        return pagesResponseJSON.items;
+    }
+    return pagesResponseJSON;
+}

--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -1,5 +1,5 @@
 import {
-    fetchPage,
+    fetchPageNoAuth,
     getOrFetchWagtailPage,
     getOrFetchManifest,
     getHomePage,
@@ -77,7 +77,8 @@ export const getPage = async () => {
     } else if (wagtailPreviewMatch) {
         const queryString = wagtailPreviewMatch[1];
         pageUrl = getPreviewPageUrl(queryString);
-        page = await fetchPage(pageUrl);
+        //page = await fetchPage(pageUrl);
+        page = await fetchPageNoAuth(pageUrl);
     } else if (appPageMatch) {
         const pageType = appPageMatch[1];
         page = {

--- a/src/js/WagtailPagesAPI.js
+++ b/src/js/WagtailPagesAPI.js
@@ -10,11 +10,16 @@ import {
     getLanguage,
     changeLanguage,
 } from "ReduxImpl/Interface";
-import { token_authed_fetch } from "js/Fetch";
+import { token_authed_fetch, unauthed_fetch } from "js/Fetch";
 
 export async function fetchManifest() {
     const allPagesMetadata = await token_authed_fetch(WAGTAIL_MANIFEST_URL);
     return allPagesMetadata;
+}
+
+export async function fetchPageNoAuth(path) {
+    const pageMetadata = await unauthed_fetch(`${BACKEND_BASE_URL}${path}`);
+    return pageMetadata;
 }
 
 export async function fetchPage(path) {


### PR DESCRIPTION
What happens on preview is that wagtail sends an internal request to a preview url, but externally in the browser we are in the backend not the frontend, meaning we have no access to previous auth. We could engineer better past this, but a quick and dirty fix is to remove auth from the preview data api, and fix the internal url being used.

This canoe PR stops the frontend trying to send a token up to the preview api.
critical change is [here](https://github.com/catalpainternational/canoe/compare/FT-New-Design-System...preview_fix?expand=1#diff-77b299bbe4e6cd36e6e4a0b8ea25d6da745b16ce65ffc8cb506b5389e27aff12R80)

required backend changes PR https://github.com/catalpainternational/canoe-backend/pull/94