### PR TITLE
correct isAvailableOffline and isPublishable for pages

### DIFF
--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -142,6 +142,7 @@ export class Page extends PublishableItem<TWagtailPageData> {
         return !!this.data.data && !!this.data.id && !!this.data.title;
     }
 
+    /** A page isAvailableOffline if it, and all of its assets and child pages, are available offline. */
     get isAvailableOffline(): boolean {
         if (!super.isAvailableOffline) {
             return false;
@@ -153,7 +154,7 @@ export class Page extends PublishableItem<TWagtailPageData> {
             return false;
         }
 
-        if (this.manifestAssets.length === 0 && this.#childPages.length === 0) {
+        if (this.manifestAssets.length === 0 && this.#assets.length === 0) {
             return true;
         }
 
@@ -169,6 +170,8 @@ export class Page extends PublishableItem<TWagtailPageData> {
         );
     }
 
+    /** A page isPublishable if it, and all of its assets, are publishable.
+     * That is, are they all present in this page's cache. */
     get isPublishable(): boolean {
         if (!super.isPublishable) {
             return false;
@@ -180,7 +183,7 @@ export class Page extends PublishableItem<TWagtailPageData> {
             return false;
         }
 
-        if (this.manifestAssets.length === 0 && this.#childPages.length === 0) {
+        if (this.manifestAssets.length === 0 && this.#assets.length === 0) {
             return true;
         }
 

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -154,7 +154,7 @@ export class Page extends PublishableItem<TWagtailPageData> {
             return false;
         }
 
-        if (this.manifestAssets.length === 0 && this.#assets.length === 0) {
+        if (this.manifestAssets.length === 0 && this.#childPages.length === 0) {
             return true;
         }
 
@@ -183,17 +183,13 @@ export class Page extends PublishableItem<TWagtailPageData> {
             return false;
         }
 
-        if (this.manifestAssets.length === 0 && this.#assets.length === 0) {
+        if (this.manifestAssets.length === 0 && this.#childPages.length === 0) {
             return true;
         }
 
         // Assets are not publishable on their own,
         // Their isPublishable status is only relevant here
-        if (!this.#assets.every((asset) => asset.isPublishable)) {
-            return false;
-        }
-
-        return this.#childPages.every((childPage) => childPage.isPublishable);
+        return this.#assets.every((asset) => asset.isPublishable);
     }
 
     get emptyItem(): TWagtailPageData {

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -109,13 +109,13 @@ export abstract class PublishableItem<T extends TPublishableItem>
     }
 
     /** This is only a very basic check.
-     * Implementing classes must call this via super, and extend to meet their requirements. */
+     * @remarks Implementing classes must call this via super, and extend to meet their requirements. */
     get isAvailableOffline(): boolean {
         return this.isValid && this.version >= 0;
     }
 
     /** This is only a very basic check.
-     * Implementing classes must call this via super, and extend to meet their requirements. */
+     * @remarks Implementing classes must call this via super, and extend to meet their requirements. */
     get isPublishable(): boolean {
         return this.isValid && this.version >= 0 && this.#requestObjectClean;
     }


### PR DESCRIPTION
# Descriptions

There is a bug in the `Page` specific part of the `isPublishable`  test.

The test is checking `isPublishable` for all of the child pages.
This is irrelevant for `isPublishable`  (although the equivalent is relevant for `isAvailableOffline`).