### PR TITLE
396 profile settings further tweaks

### DIFF
--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -16,7 +16,7 @@ LanguageSelector {
   label {
     color: $gray-1;
     font-size: 1em;
-    font-weight: 500;
+    font-weight: 400;
     display: block;
     margin-bottom: 10px;
   }
@@ -31,7 +31,7 @@ LanguageSelector {
       border-bottom: 2px solid $app-accent-color;
       width: 8px;
       height: 8px;
-      top: 14px;
+      top: 13px;
       right: 15px;
       transform: rotate(45deg);
     }
@@ -40,14 +40,15 @@ LanguageSelector {
   #language {
     width: 100%;
     height: 40px;
-    font-size: 1em;
+    font-size: 0.9em;
     font-weight: 300;
     color: $gray-1;
-    margin-bottom: 15%;
+    margin-bottom: 10%;
     border: 1px solid $gray-7;
     border-radius: 3px;
     background-color: $white;
     padding-left: 10px;
+    -webkit-appearance: none;
     appearance: none;
     box-shadow: inset 0 2px 3px 0 rgba(42,57,66,0.1);
 
@@ -113,7 +114,6 @@ LanguageSelector {
 
     label {
       color: $gray-1;
-      font-size: 1em;
-      font-weight: 500;
+      font-weight: 400;
     }
 }

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -59,7 +59,7 @@ LanguageSelector {
 }
 
 .notifications-toggle {
-    margin: 20px 0;
+    margin: 25px 0;
     align-items: center;
     display: flex;
 


### PR DESCRIPTION
Further tweaks as per feedback on issue #396 
- increase space between toggle and below label
- change the weight of the labels
- add `-webkit` prefix to `appearance` to ensure default dropdown styles are removed on safari
- decrease space above log out button
- ensure vertical centring of chevron

As a note to Andy - the notifications toggle doesn't work in dev. I've attached a screenshot of what it looks like when it's on v off
![Screen Shot 2021-02-22 at 4 56 49 pm](https://user-images.githubusercontent.com/12974326/108668277-04d65480-752f-11eb-9d95-0d671f1cf37c.png)
![Screen Shot 2021-02-22 at 4 56 31 pm](https://user-images.githubusercontent.com/12974326/108668281-06a01800-752f-11eb-90c4-b07679579736.png)
