### PR TITLE
Handle page initialisation errors better

### DIFF
--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -235,7 +235,12 @@ export class Page extends PublishableItem<TWagtailPageData> {
 
     async initialiseFromResponse(resp: Response): Promise<boolean> {
         this.status.cacheStatus = "loading";
-        this.data = await resp.json();
+        try {
+            this.data = await resp.json();
+        } catch {
+            // We assume a bad cached entry, i.e. bad json
+            return false;
+        }
 
         // And store the page data in Redux
         this.StoreDataToStore();


### PR DESCRIPTION
# Description

If a page's cached entry is incorrectly formatted the following line from page's `initialiseFromResponse` will throw an error.
```
this.data = await resp.json();
```

However, the calling method expects a boolean result instead to indicate any problems (i.e. `false`).

This fixes that failure and returns the correct result.

## Note:
It may be desirable to change this line in `routing.js`
```
page.initialiseByRequest();
```

Because it will now reliably get a boolean indicating whether the page has been successfully initialised or not. e.g.
```
const isInitialised = await page.initialiseByRequest();
```

