### PR TITLE
441 courses listing page tweaks

### DIFF
--- a/src/riot/Components/Card.riot.html
+++ b/src/riot/Components/Card.riot.html
@@ -4,7 +4,7 @@
             <span class="card-status"><span class="icon"></span></span>
         </div>
         <div class="card-title">
-            <h5>{props.title}</h5>
+            <h5 class="clamp-3-lines">{props.title}</h5>
             <progress
                 if="{props.status === 'in-progress'}"
                 value="{props.progressValue}"

--- a/src/riot/Components/TagList.riot.html
+++ b/src/riot/Components/TagList.riot.html
@@ -3,8 +3,8 @@
         <a
             each="{tag in props.tags}"
             class="tag {props.selectedTags && props.selectedTags.includes(tag) ? 'selected' : ''}"
-            onclick="{e => { 
-                props.onTagClick(e.srcElement.innerText.toLowerCase(), false)
+            onclick="{e => {
+                props.onTagClick(e.srcElement.innerText, false)
             }}"
         >
             <p>{tag}</p>

--- a/src/riot/Components/TagList.riot.html
+++ b/src/riot/Components/TagList.riot.html
@@ -4,7 +4,7 @@
             each="{tag in props.tags}"
             class="tag {props.selectedTags && props.selectedTags.includes(tag) ? 'selected' : ''}"
             onclick="{e => {
-                props.onTagClick(e.srcElement.innerText, false)
+                props.onTagClick(e.srcElement.innerText.toLowerCase(), false)
             }}"
         >
             <p>{tag}</p>

--- a/src/riot/WagtailPages/AllCoursesPage.riot.html
+++ b/src/riot/WagtailPages/AllCoursesPage.riot.html
@@ -29,17 +29,17 @@
             <template if="{Array.isArray(state.sortedListOfCourses)}">
                 <template if="{state.currentCourse && !state.currentCourse.isFinished()}">
                     <h5 class="section-title">{ TRANSLATIONS.continueLearning() }</h5>
-                    <Card
-                        status="{courseStatus(state.currentCourse)}"
-                        title="{state.currentCourse.title}"
-                        link="{state.currentCourse.id}"
-                        progressValue="{state.currentCourse.numberOfFinishedLessons}"
-                        progressMax="{state.currentCourse.numberOfLessons}"
-                    ></Card>
+                    <div class="card-container full-width">
+                        <Card
+                            status="{courseStatus(state.currentCourse)}"
+                            title="{state.currentCourse.title}"
+                            link="{state.currentCourse.id}"
+                            progressValue="{state.currentCourse.numberOfFinishedLessons}"
+                            progressMax="{state.currentCourse.numberOfLessons}"
+                        ></Card>
+                    </div>
                 </template>
-                <h5 class="section-title">
-                    { TRANSLATIONS.allCourses() }
-                </h5>
+                <h5 class="section-title">{ TRANSLATIONS.allCourses() }</h5>
                 <div class="card-container">
                     <Card
                         each="{course in state.sortedListOfCourses}"

--- a/src/riot/WagtailPages/AllCoursesPage.riot.html
+++ b/src/riot/WagtailPages/AllCoursesPage.riot.html
@@ -37,10 +37,7 @@
                         progressMax="{state.currentCourse.numberOfLessons}"
                     ></Card>
                 </template>
-                <h5
-                    if="{state.currentCourse && !state.currentCourse.isFinished()}"
-                    class="section-title"
-                >
+                <h5 class="section-title">
                     { TRANSLATIONS.allCourses() }
                 </h5>
                 <div class="card-container">

--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -22,12 +22,14 @@
             </div>
             <template if="{state.lessons.length > 0 && props.examCards.length > 0}">
                 <h5 class="section-title">{ TRANSLATIONS.course_exam() }</h5>
-                <Card
-                    title="{courseExamTitle()}"
-                    description="{props.wagtailPage.hasUserTriedExam() ? `${TRANSLATIONS.highestScore()}: ${props.wagtailPage.getExamHighScore()}%` : ''}"
-                    link="{props.wagtailPage.id}/exam/0"
-                    status="{examStatus(props.wagtailPage)}"
-                ></Card>
+                <div class="card-container full-width">
+                    <Card
+                        title="{courseExamTitle()}"
+                        description="{props.wagtailPage.hasUserTriedExam() ? `${TRANSLATIONS.highestScore()}: ${props.wagtailPage.getExamHighScore()}%` : ''}"
+                        link="{props.wagtailPage.id}/exam/0"
+                        status="{examStatus(props.wagtailPage)}"
+                    ></Card>
+                </div>
             </template>
         </div>
     </div>

--- a/src/scss/_all-courses.scss
+++ b/src/scss/_all-courses.scss
@@ -6,12 +6,20 @@ AllCoursesPage {
     .with-swoop {
         height: unset;
 
+        & h3 {
+            margin-bottom: 0.5em;
+        }
+
         & > .filter-copy-container {
             display: grid;
             grid-template-columns: 1fr 40px;
-            column-gap: 15px;
+            column-gap: 15%;
             align-items: center;
             margin-bottom: 20px;
+
+            & > p {
+                margin: 0;
+            }
         }
 
         .show-tags {

--- a/src/scss/_all-courses.scss
+++ b/src/scss/_all-courses.scss
@@ -32,6 +32,10 @@ AllCoursesPage {
         }
     }
 
+    .tag-container > .tag p {
+        text-transform: none;
+    }
+
     .card-image {
         @extend %stock-course;
     }

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -36,17 +36,9 @@
             line-height: 1.2em;
             height: calc(3 * 1.2em);
             overflow: hidden;
-            position: relative;
-
-            &::after {
-                content: '';
-                position: absolute;
-                bottom: 0;
-                right: 0;
-                width: 7ch;
-                height: 1.2em;
-                background: linear-gradient(to right,rgba($white, 0),rgba($white, 1) 70%);
-            }
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
         }
     }
 

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -21,13 +21,30 @@
 
     .card-title {
         box-sizing: border-box;
-        min-height: 70px;
+        min-height: 100px;
         padding: 15px;
         overflow: hidden;
 
         h5 {
             margin: 0;
             color: $gray-1;
+        }
+
+        .clamp-3-lines {
+            line-height: 1.2em;
+            height: calc(3 * 1.2em);
+            overflow: hidden;
+            position: relative;
+
+            &::after {
+                content: '';
+                position: absolute;
+                bottom: 0;
+                right: 0;
+                width: 7ch;
+                height: 1.2em;
+                background: linear-gradient(to right,rgba($white, 0),rgba($white, 1) 70%);
+            }
         }
     }
 

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -5,7 +5,9 @@
     border: 1px solid $gray-7;
     box-shadow: 0 5px 10px 0 rgba(42, 57, 66, 0.2);
     background-color: $gray-10;
-    height: 175px;
+    height: 200px;
+    max-width: 170px;
+    margin: 0 auto;
     position: relative;
 
     .card-image {
@@ -95,6 +97,10 @@
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: auto;
     justify-content: space-between;
+
+    @media only screen and (min-width: 500px) {
+        grid-template-columns: repeat(3, 1fr);
+    }
 }
 
 // Legacy needs this (?)

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -93,6 +93,14 @@
     @media only screen and (min-width: 500px) {
         grid-template-columns: repeat(3, 1fr);
     }
+
+    &.full-width {
+        grid-template-columns: 1fr;
+
+        .card {
+            max-width: unset;
+        }
+    }
 }
 
 // Legacy needs this (?)

--- a/src/scss/_course.scss
+++ b/src/scss/_course.scss
@@ -11,9 +11,5 @@ CoursePage {
         h2 {
             margin-bottom: 35px;
         }
-
-        .section-title {
-            margin: 1.5em 0;
-        }
     }
 }

--- a/src/scss/_taglist.scss
+++ b/src/scss/_taglist.scss
@@ -9,6 +9,7 @@ TagList {
             @extend %absolutely-center;
             @extend %truncate-with-ellipsis;
             margin: 0;
+            text-transform: uppercase;
             font-weight: 400;
             text-align: center;
         }

--- a/src/scss/_taglist.scss
+++ b/src/scss/_taglist.scss
@@ -9,7 +9,6 @@ TagList {
             @extend %absolutely-center;
             @extend %truncate-with-ellipsis;
             margin: 0;
-            text-transform: uppercase;
             font-weight: 400;
             text-align: center;
         }

--- a/src/scss/_top_menu.scss
+++ b/src/scss/_top_menu.scss
@@ -30,6 +30,10 @@ TopMenu {
         font-weight: 200;
     }
 
+    h4, h5 {
+        max-width: 70%;
+    }
+
     span {
         display: inline-block;
     }

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -58,7 +58,7 @@ p {
 h5.section-title {
     text-transform: uppercase;
     display: flex;
-    margin: 1em 0;
+    margin: 1.5em 0;
 }
 
 a {


### PR DESCRIPTION
addresses feedback in #441

- add the 'All Courses' title
- fixes to the spacing in the header (under the title and between the paragraph and filter button)
- remove uppercase styling for the filter tags
- styles to clamp card titles to 3 lines. this is a quick and simple solution, though not perfect. just adds a height limit and some styles to the `::after` pseudo element to fade the title out: (this change also fixes the positioning of the title & progress bar)

![Screen Shot 2021-02-24 at 2 55 33 pm](https://user-images.githubusercontent.com/12974326/108949674-f1ef8b80-76b8-11eb-8669-85f86f4bb6f3.png)

- make the card layout more responsive & add a max-width to cards:
![caard-responsive](https://user-images.githubusercontent.com/12974326/108949615-d7b5ad80-76b8-11eb-8dc5-15e48242b65a.gif)

