### PR TITLE
Support for skipping the serviceworker installation

### DIFF
--- a/canoe-environment-default.js
+++ b/canoe-environment-default.js
@@ -4,6 +4,7 @@
 module.exports = {
     GA_TAG: false,
     API_BASE_URL: "http://localhost:8000",
+    SKIP_SW: false,
     DONT_SHOW_COMPLETIONS_AFTER: "2020-2-15",
     APPLICATION_SERVER_KEY: "",
     WEBPACK_CONFIG: {

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ subscribeToStore(() => {
             document.querySelector("#service-worker-notsupported").hidden = false;
             break;
         case "controlling":
+        case "skip_sw":
             // hide the loading splash
             record_bootstate().then(_is_nonblank_slate => {
                 document.querySelector("#preapp-messages").hidden = true;

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -91,7 +91,8 @@ export const userShouldLogin = () => {
     const is_deauthed = localStorage.getItem(USER_IS_AUTHED_STORAGE_KEY) === "false";
     const is_firstboot = sessionStorage.getItem(EMPTY_SLATE_BOOT_KEY) === "true";
     const is_user_logged_in = isUserLoggedIn();
-    return is_deauthed || is_firstboot || !is_user_logged_in;
+    const skip_sw = process.env.SKIP_SW;
+    return is_deauthed || is_firstboot && !skip_sw || !is_user_logged_in;
 };
 
 export const getUsername = () => {

--- a/src/js/ServiceWorkerManagement.js
+++ b/src/js/ServiceWorkerManagement.js
@@ -9,7 +9,13 @@ import { ON_ADD_TO_HOME_SCREEN } from "js/Events";
 
 const SW_UPDATE_INTERVAL = 1000 * 10 * 60 * 4;
 
+export const SKIP_SW = process.env.SKIP_SW;
+
 export async function initializeServiceWorker() {
+    if(SKIP_SW) {
+        changeServiceWorkerState("skip_sw");
+        return;
+    }
     if (!navigator.serviceWorker) {
         changeServiceWorkerState("notsupported")
         return;

--- a/src/js/redux/ducks/ServiceWorker.js
+++ b/src/js/redux/ducks/ServiceWorker.js
@@ -20,6 +20,8 @@ const serviceWorkerState = (state = "unknown", action) => {
                     return state === "controlling" ? "update-waiting" : "install-failed";
                 case "update-waiting":
                     return "update-waiting";
+                case "skip_sw":
+                    return "skip_sw";
                 case "notsupported":
                     return "notsupported";
                 default:


### PR DESCRIPTION
This allows a developer to avoid the painful refresh/wait/refresh/wait cycle bypassing service worker requirement.
It should not be used in production, or when testing serviceworker related features.

Edit your project level `canoe-environment.js` file and add this.
```javascript
    SKIP_SW: true,
```
