### PR TITLE
(FE) Add HTML5 card to lesson content

### DIFF
--- a/canoe-environment-default.js
+++ b/canoe-environment-default.js
@@ -4,13 +4,13 @@
 module.exports = {
     GA_TAG: false,
     API_BASE_URL: "http://localhost:8000",
-    SKIP_SW: false,
+    SKIP_SW: true,
     DONT_SHOW_COMPLETIONS_AFTER: "2020-2-15",
     APPLICATION_SERVER_KEY: "",
     WEBPACK_CONFIG: {
         devServer: {
             port: 8080,
-        }
+        },
     },
-    GUEST_USERNAME: "Guest"
+    GUEST_USERNAME: "Guest",
 };

--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -27,6 +27,10 @@ export const getMediaUrl = (mediaPath) => {
     return `${BACKEND_BASE_URL}${MEDIA_PATH}/${mediaPath}`;
 };
 
+export const getHtmlUrl = (htmlPath) => {
+    return `${BACKEND_BASE_URL}${htmlPath}`;
+};
+
 export const resolveMedia = (mediaID) => {
     return getOrFetchManifest()
         // Choose smallest media item. Much more elaborate strategies are possible, but they need coordination with the backend 

--- a/src/riot/Lesson/Html5Card.riot.html
+++ b/src/riot/Lesson/Html5Card.riot.html
@@ -13,7 +13,7 @@
     </div>
     <script>
         import { getHtmlUrl } from "js/utilities";
-        
+
         export default {
             state: {
                 iFrameElement: undefined,
@@ -34,22 +34,8 @@
             openFullScreen() {
                 if (this.state.iFrameElement.requestFullscreen) {
                     this.state.iFrameElement.requestFullscreen();
-                } //else if (iFrameEl.webkitRequestFullscreen) {
-                //     iFrameEl.webkitRequestFullscreen();
-                // } else if (iFrameEl.msRequestFullscreen) {
-                //     iFrameEl.msRequestFullscreen();
-                // }
+                }
             },
-
-            // closeFullScreen() {
-            //     if (document.exitFullscreen) {
-            //         document.exitFullscreen();
-            //     } else if (document.webkitExitFullscreen) {
-            //         document.webkitExitFullscreen();
-            //     } else if (document.msExitFullscreen) {
-            //         document.msExitFullscreen();
-            //     }
-            // },
         };
     </script>
 </Html5Card>

--- a/src/riot/Lesson/Html5Card.riot.html
+++ b/src/riot/Lesson/Html5Card.riot.html
@@ -1,15 +1,19 @@
 <Html5Card>
     <div>
         <h3>{props.card.title}</h3>
-        <iframe src="{props.card.url}" title="{props.card.title}"></iframe>
+        <!-- <iframe src="{props.card.url}" title="{props.card.title}"></iframe> -->
+        <iframe id="animation" title="{props.card.title}"></iframe>
+        <!-- <iframe src="http://catalpa.io"></iframe> -->
+        <!-- <iframe src="https://www.youtube.com/embed/93hq0YU3Gqk" title="{props.card.title}"></iframe> -->
     </div>
     <script>
         import { getHtmlUrl } from "js/utilities";
 
         export default {
-            onMounted() {
+            onMounted(props, state) {
+                document.getElementById("animation").src = "https://catalpa.io"; //props.card.url;
                 console.log(this.props.card);
-                console.log(getHtmlUrl(this.props.card.url));
+                // console.log(getHtmlUrl(this.props.card.url));
             },
 
             getHtmlUrl(documentPath) {

--- a/src/riot/Lesson/Html5Card.riot.html
+++ b/src/riot/Lesson/Html5Card.riot.html
@@ -1,15 +1,55 @@
 <Html5Card>
-    <div>
+    <div class="html-card">
         <h3>{props.card.title}</h3>
-        <iframe src="{getHtmlUrl(props.card.url)}" title="{props.card.title}" allowfullscreen></iframe>
+        <iframe
+            id="iFrame"
+            src="{getHtmlUrl(props.card.url)}"
+            title="{props.card.title}"
+            allowfullscreen
+        ></iframe>
+        <button class="btn-primary" onclick="{openFullScreen}">
+            { TRANSLATIONS.fullScreen() }
+        </button>
     </div>
     <script>
         import { getHtmlUrl } from "js/utilities";
-
+        
         export default {
+            state: {
+                iFrameElement: undefined,
+            },
+
+            TRANSLATIONS: {
+                fullScreen: () => gettext("View full screen"),
+            },
+
+            onMounted() {
+                this.update({ iFrameElement: document.getElementById("iFrame") });
+            },
+
             getHtmlUrl(documentPath) {
                 return `${getHtmlUrl(documentPath)}`;
             },
+
+            openFullScreen() {
+                if (this.state.iFrameElement.requestFullscreen) {
+                    this.state.iFrameElement.requestFullscreen();
+                } //else if (iFrameEl.webkitRequestFullscreen) {
+                //     iFrameEl.webkitRequestFullscreen();
+                // } else if (iFrameEl.msRequestFullscreen) {
+                //     iFrameEl.msRequestFullscreen();
+                // }
+            },
+
+            // closeFullScreen() {
+            //     if (document.exitFullscreen) {
+            //         document.exitFullscreen();
+            //     } else if (document.webkitExitFullscreen) {
+            //         document.webkitExitFullscreen();
+            //     } else if (document.msExitFullscreen) {
+            //         document.msExitFullscreen();
+            //     }
+            // },
         };
     </script>
 </Html5Card>

--- a/src/riot/Lesson/Html5Card.riot.html
+++ b/src/riot/Lesson/Html5Card.riot.html
@@ -1,7 +1,7 @@
 <Html5Card>
     <div>
         <h3>{props.card.title}</h3>
-        <iframe src="{props.card.url}" title="{props.card.title}" height="400" width="300"></iframe>
+        <iframe src="{props.card.url}" title="{props.card.title}"></iframe>
     </div>
     <script>
         import { getHtmlUrl } from "js/utilities";

--- a/src/riot/Lesson/Html5Card.riot.html
+++ b/src/riot/Lesson/Html5Card.riot.html
@@ -1,23 +1,13 @@
 <Html5Card>
     <div>
         <h3>{props.card.title}</h3>
-        <!-- <iframe src="{props.card.url}" title="{props.card.title}"></iframe> -->
-        <iframe id="animation" title="{props.card.title}"></iframe>
-        <!-- <iframe src="http://catalpa.io"></iframe> -->
-        <!-- <iframe src="https://www.youtube.com/embed/93hq0YU3Gqk" title="{props.card.title}"></iframe> -->
+        <iframe src="{getHtmlUrl(props.card.url)}" title="{props.card.title}" allowfullscreen></iframe>
     </div>
     <script>
         import { getHtmlUrl } from "js/utilities";
 
         export default {
-            onMounted(props, state) {
-                document.getElementById("animation").src = "https://catalpa.io"; //props.card.url;
-                console.log(this.props.card);
-                // console.log(getHtmlUrl(this.props.card.url));
-            },
-
             getHtmlUrl(documentPath) {
-                console.log(`${getHtmlUrl(documentPath)}`);
                 return `${getHtmlUrl(documentPath)}`;
             },
         };

--- a/src/riot/Lesson/Html5Card.riot.html
+++ b/src/riot/Lesson/Html5Card.riot.html
@@ -1,0 +1,21 @@
+<Html5Card>
+    <div>
+        <h3>{props.card.title}</h3>
+        <iframe src="{props.card.url}" title="{props.card.title}" height="400" width="300"></iframe>
+    </div>
+    <script>
+        import { getHtmlUrl } from "js/utilities";
+
+        export default {
+            onMounted() {
+                console.log(this.props.card);
+                console.log(getHtmlUrl(this.props.card.url));
+            },
+
+            getHtmlUrl(documentPath) {
+                console.log(`${getHtmlUrl(documentPath)}`);
+                return `${getHtmlUrl(documentPath)}`;
+            },
+        };
+    </script>
+</Html5Card>

--- a/src/riot/Lesson/LessonContent.riot.html
+++ b/src/riot/Lesson/LessonContent.riot.html
@@ -11,11 +11,22 @@
         <template if="{props.description}">
             <p class="resource-description">{ props.description }</p>
         </template>
-        <template if="{props.resourceId === 'resources'}" each="{card in props.lessonContent.cards}">
+        <template
+            if="{props.resourceId === 'resources'}"
+            each="{card in props.lessonContent.cards}"
+        >
             <Raw if="{card.tag === 'raw'}" html="{card.content}" class="content-block"></Raw>
             <BasicCard if="{card.tag === 'basic'}" card="{card}" class="content-block"></BasicCard>
-            <AudioCard if="{card.media_type === 'audio'}" media="{card}" class="content-block"></AudioCard>
-            <VideoCard if="{card.media_type === 'video'}" media="{card}" class="content-block"></VideoCard>
+            <AudioCard
+                if="{card.media_type === 'audio'}"
+                media="{card}"
+                class="content-block"
+            ></AudioCard>
+            <VideoCard
+                if="{card.media_type === 'video'}"
+                media="{card}"
+                class="content-block"
+            ></VideoCard>
             <QuoteCard if="{card.tag === 'quote'}" card="{card}" class="content-block"></QuoteCard>
             <ListCard if="{card.tag === 'list'}" card="{card}" class="content-block"></ListCard>
             <PdfCard if="{card.tag === 'pdf'}" card="{card}" class="content-block"></PdfCard>
@@ -49,9 +60,16 @@
                 if="{props.lessonContent.cards[state.cardIdx].tag === 'pdf'}"
                 card="{props.lessonContent.cards[state.cardIdx]}"
             />
+            <Html5Card
+                if="{props.lessonContent.cards[state.cardIdx].tag === 'html5'}"
+                card="{props.lessonContent.cards[state.cardIdx]}"
+            />
         </template>
     </LessonFrame>
-    <div if="{props.isLessonPage && state.cardIdx !== props.lessonContent.cards.length}" class="bottom-buttons">
+    <div
+        if="{props.isLessonPage && state.cardIdx !== props.lessonContent.cards.length}"
+        class="bottom-buttons"
+    >
         <div>
             <a if="{state.cardIdx > 0}" class="has-circle" onclick="{goBack}">
                 <span class="arrow"></span>
@@ -92,6 +110,7 @@
         import QuoteCard from "RiotTags/Components/QuoteCard.riot.html";
         import ListCard from "RiotTags/Lesson/ListCard.riot.html";
         import PdfCard from "RiotTags/Lesson/PdfCard.riot.html";
+        import Html5Card from "RiotTags/Lesson/Html5Card.riot.html";
 
         import { getLessonCardIdx, getNextCardsUrl, getPreviousCardsUrl } from "js/Routing";
         import { setComplete } from "Actions/completion";
@@ -112,6 +131,7 @@
                 videocard: VideoCard,
                 audiocard: AudioCard,
                 pdfcard: PdfCard,
+                html5card: Html5Card,
             },
 
             TRANSLATIONS: {

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -198,6 +198,24 @@ LessonContent .content {
         width: 100%;
     }
 
+    Html5Card {
+        height: inherit;
+
+        .html-card {
+            display: flex;
+            flex-direction: column;
+            height: inherit;
+        }
+
+        h3 {
+            margin-top: 0;
+        }
+
+        button {
+            margin-top: 1em;
+        }
+    }
+
     basiccard,
     quotecard,
     listcard {
@@ -285,7 +303,7 @@ LessonContent .content {
     iframe {
         border: 3px solid $app-accent-color;
         width: 100%;
-        height: 400px;
+        flex: 1;
         border-radius: 15px;
     }
 }

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -192,7 +192,8 @@ LessonContent .content {
     listcard,
     VideoCard,
     AudioCard,
-    PdfCard {
+    PdfCard,
+    Html5Card {
         flex: 1;
         width: 100%;
     }
@@ -279,6 +280,10 @@ LessonContent .content {
 
     p.error-message {
         color: red;
+    }
+
+    iframe {
+        border: none;
     }
 }
 

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -283,7 +283,10 @@ LessonContent .content {
     }
 
     iframe {
-        border: none;
+        border: 3px solid $app-accent-color;
+        width: 100%;
+        height: 400px;
+        border-radius: 15px;
     }
 }
 


### PR DESCRIPTION
Frontend portion for https://github.com/catalpainternational/canoe/issues/466 and https://github.com/catalpainternational/canoe/issues/380

Run this with the corresponding canoe-backend branch `380-explore-animated-interaction` with the associated PR https://github.com/catalpainternational/canoe-backend/pull/103

For the HTML5 riot tag, I added a method for `closeFullScreen()` which may not be necessary since we might be able to use the default browser full screen controls/UX. 