### PR TITLE
504 offlining audit fixes

### DIFF
--- a/src/riot/WagtailPages/AllCoursesPage.riot.html
+++ b/src/riot/WagtailPages/AllCoursesPage.riot.html
@@ -14,8 +14,8 @@
                 </a>
             </div>
             <TagList
-                if="{Array.isArray(state.sortedListOfCourses) && state.sortedListOfCourses.length > 0 && state.listOfTags.length > 0 && state.showTagList}"
-                tags="{state.listOfTags}"
+                if="{ state.showTagList }"
+                tags="{ page.tags }"
                 onTagClick="{onTagClick}"
                 selectedTags="{state.selectedTags}"
             ></TagList>

--- a/src/riot/WagtailPages/AllCoursesPage.riot.html
+++ b/src/riot/WagtailPages/AllCoursesPage.riot.html
@@ -35,7 +35,7 @@
                             link="{page.currentCourse.loc_hash}"
                             progressValue="{page.currentCourse.numberOfFinishedLessons}"
                             progressMax="{page.currentCourse.numberOfLessons}"
-                            imageUrl="{state.currentCourse.imageUrl}"
+                            imageUrl="{ state.currentCourse.cardImage }"
                         ></Card>
                     </div>
                 </template>
@@ -50,7 +50,7 @@
                         progress-value="{course.numberOfFinishedLessons}"
                         progress-max="{course.numberOfLessons}"
                         progressMax="{course.numberOfLessons}"
-                        imageUrl="{course.imageUrl}"
+                        imageUrl="{ course.cardImage }"
                     ></Card>
                 </div>
 

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -135,6 +135,14 @@ export class Page extends PublishableItem<TWagtailPageData> {
         return this.manifestData?.depth || 0;
     }
 
+    get cardImage(): string {
+        return this.manifestData?.card_image || "";
+    }
+
+    get tags(): string[] {
+        return this.manifestData?.tags || [];
+    }
+
     get contentType(): string {
         return "application/json";
     }

--- a/src/ts/Implementations/Specific/CoursePage.ts
+++ b/src/ts/Implementations/Specific/CoursePage.ts
@@ -13,10 +13,6 @@ export default class CoursePage extends Page {
     get lessons(): any {
         return this.childPages;
     }
-    get tags(): string[] {
-        return this.data.tags;
-    }
-
     get hasExam(): boolean {
         return this.data.data?.has_exam;
     }


### PR DESCRIPTION
To be run against canoe-backend `list_requirements_in_manifest` from https://github.com/catalpainternational/canoe-backend/pull/111

- Adds Page.ts accessors for tags and cardImage, removing the CoursePage.ts tags function
- Fixes the tag list which was broken by a bad merge