### PR TITLE
504 list pages fixes

### DIFF
--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -108,9 +108,11 @@ export const isGuestUser = () => {
 };
 
 export const getUserId = () => {
-    return getUser().userId;
+    const user = getUser();
+    return user ? user.userId : null;
 };
 
 export const getUserGroups = () => {
-    return getUser().groups;
+    const user = getUser();
+    return user ? user.groups : null;
 };

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -32,6 +32,8 @@
             if="{state.page.type === 'resourcearticle'}"
         ></ResourceArticle>
         <AllTopicsPage if="{ state.page.type === 'learningactivitieshomepage'}"></AllTopicsPage>
+        <TopicPage if="{ state.page.type === 'learningactivitytopicpage'}"></TopicPage>
+        <LearningActivityPage if="{ state.page.type === 'learningactivitypage'}"></LearningActivityPage>
 
         <BottomMenu page="{state.page}"></BottomMenu>
         <PushSubscription></PushSubscription>
@@ -61,6 +63,8 @@
         import LessonOverview from "RiotTags/Lesson/LessonOverview.riot.html";
         import ResourceArticle from "RiotTags/WagtailPages/ResourceArticle.riot.html";
         import AllTopicsPage from "RiotTags/WagtailPages/AllTopicsPage.riot.html";
+        import TopicPage from "RiotTags/WagtailPages/TopicPage.riot.html";
+        import LearningActivityPage from "RiotTags/WagtailPages/LearningActivityPage.riot.html";
 
         function App() {
             function readState() {
@@ -106,6 +110,8 @@
             toast: Toast,
             resourcearticle: ResourceArticle,
             alltopicspage: AllTopicsPage,
+            topicpage: TopicPage,
+            learningactivitypage: LearningActivityPage,
             loadingdots: LoadingDots,
         }
 

--- a/src/riot/Screens/Resources.riot.html
+++ b/src/riot/Screens/Resources.riot.html
@@ -4,19 +4,19 @@
     </TopMenu>
     <div if="{state.hash == null}" class="content-wrapper">
         <SearchBar
-            if="{state.page.resources.length > 0}"
+            if="{page.resources.length > 0}"
             searchString="{state.searchString}"
             submitSearch="{submitSearch}"
         ></SearchBar>
         <TagList
-            if="{state.listOfAllTags.length > 0 && state.page.resources.length > 0}"
-            tags="{state.listOfAllTags}"
-            onTagClick="{onTagClick}"
-            selectedTags="{state.selectedTags}"
+            if="{ page.all_tags.size }"
+            tags="{ page.all_tags }"
+            onTagClick="{ onTagClick }"
+            selectedTags="{ state.selectedTags }"
         ></TagList>
         <div class="list-resources">
             <a
-                each="{resource in state.page.resources}"
+                each="{resource in page.resources}"
                 if="{isResourceVisible(resource)}"
                 class="resource-card"
                 href="#{resource.loc_hash}"
@@ -31,11 +31,7 @@
                 <h6 if="{ resource.ready }">{resource.description}</h6>
             </a>
         </div>
-        <LoadingDots
-            if="{state.isLoading}"
-            extrastyleclasses="dark"
-        ></LoadingDots>
-        <p if="{!state.isLoading && state.page.resources.length === 0}">
+        <p if="{ page.resources.length === 0}">
             { TRANSLATIONS.noArticlesYet() }
         </p>
     </div>
@@ -43,34 +39,25 @@
     <script>
         import TagList from "RiotTags/Components/TagList.riot.html";
         import SearchBar from "RiotTags/Components/SearchBar.riot.html";
-        import LoadingDots from "RiotTags/Components/LoadingDots.riot.html";
         import TopMenu from "RiotTags/Components/TopMenu.riot.html";
 
         import { getRoute } from "ReduxImpl/Interface";
 
-        import { getSearchQueryFromUrl, parseURLHash } from "js/Routing";
-        import { getResources } from "js/WagtailPagesAPI";
         import {
-            getTagsFromPages,
             doPageTagsMatchSelections,
             doesQueryMatchSearchContent,
         } from "js/SearchAndFiltering";
-
-        import ResourceArticle from "js/ResourceArticle";
 
         export default {
             state: {
                 selectedTags: [],
                 searchString: "",
-                articles: [],
-                listOfAllTags: [],
                 isLoading: false,
             },
 
             components: {
                 taglist: TagList,
                 searchbar: SearchBar,
-                loadingdots: LoadingDots,
                 topmenu: TopMenu,
             },
 
@@ -80,77 +67,26 @@
             },
             
             onBeforeMount() {
-                this.state.page = getRoute().page;
-                this.state.isLoading = !this.state.page.ready;
+                this.page = getRoute().page;
+                this.state.isLoading = !this.page.ready;
             },
             onBeforeUpdate() {
-                this.state.isLoading = !this.state.page.ready;
-            },
-
-            async onMounted() {
-                const articles = (await getResources()).map(
-                    (resource) => new ResourceArticle(resource)
-                );
-                const listOfAllTags = getTagsFromPages(articles);
-                this.update({
-                    articles,
-                    listOfAllTags,
-                    selectedTags: [],
-                });
-
-                const urlParams = this.generateUrlParams();
-
-                const query = urlParams.get("qs");
-                if (!!query) {
-                    this.update({ searchString: decodeURIComponent(query) });
-                }
-
-                const filter = urlParams.getAll("filter");
-                if (filter.length > 0) {
-                    for (const tag of filter) {
-                        if (listOfAllTags.includes(tag)) {
-                            this.onTagClick(decodeURIComponent(tag), true);
-                        }
-                    }
-                }
-            },
-
-            generateUrlParams() {
-                const queryStringFromUrl = getSearchQueryFromUrl();
-                return new URLSearchParams(queryStringFromUrl);
+                this.state.isLoading = !this.page.ready;
             },
 
             onTagClick(clickedTag, isFromUrl) {
-                const urlParams = this.generateUrlParams();
-
                 if (this.state.selectedTags.includes(clickedTag)) {
                     const tagIndex = this.state.selectedTags.indexOf(
                         clickedTag
                     );
                     this.state.selectedTags.splice(tagIndex, 1);
-                    urlParams.delete("filter");
-
-                    if (this.state.selectedTags.length > 0) {
-                        for (const tag of this.state.selectedTags) {
-                            const pendingTag = tag.toLowerCase();
-                            urlParams.append("filter", pendingTag);
-                        }
-                    }
-                    this.replaceUrlQuery(urlParams);
                 } else {
                     this.state.selectedTags.push(clickedTag);
-                    urlParams.append("filter", clickedTag);
-                    !isFromUrl && this.replaceUrlQuery(urlParams);
-                    this.update();
                 }
                 this.update();
             },
 
             submitSearch(searchString) {
-                const urlParams = this.generateUrlParams();
-
-                urlParams.set("qs", searchString);
-                this.replaceUrlQuery(urlParams);
                 this.update({ searchString });
             },
 
@@ -173,14 +109,6 @@
 
                 const show = isQueryMatch && isTagMatch;
                 return show;
-            },
-
-            replaceUrlQuery(urlParams) {
-                window.history.replaceState(
-                    {},
-                    "",
-                    `${location.pathname}#resources?${urlParams}`
-                );
             },
         };
     </script>

--- a/src/riot/WagtailPages/AllCoursesPage.riot.html
+++ b/src/riot/WagtailPages/AllCoursesPage.riot.html
@@ -15,7 +15,7 @@
             </div>
             <TagList
                 if="{ state.showTagList }"
-                tags="{ page.tags }"
+                tags="{ page.all_tags }"
                 onTagClick="{onTagClick}"
                 selectedTags="{state.selectedTags}"
             ></TagList>
@@ -25,37 +25,35 @@
             <LoadingDots if="{!page.ready}"
                 extrastyleclasses="dark"
             ></LoadingDots>
-            <template if="{page.ready}">
-                <template if="{state.currentCourse && !state.currentCourse.isFinished()}">
-                    <h5 class="section-title">{ TRANSLATIONS.continueLearning() }</h5>
-                    <div class="card-container full-width">
-                        <Card
-                            status="{courseStatus(page.currentCourse)}"
-                            title="{page.currentCourse.title}"
-                            link="{page.currentCourse.loc_hash}"
-                            progressValue="{page.currentCourse.numberOfFinishedLessons}"
-                            progressMax="{page.currentCourse.numberOfLessons}"
-                            imageUrl="{ state.currentCourse.cardImage }"
-                        ></Card>
-                    </div>
-                </template>
-                <h5 class="section-title">{ TRANSLATIONS.allCourses() }</h5>
-                <div class="card-container">
+            <template if="{state.currentCourse && !state.currentCourse.isFinished()}">
+                <h5 class="section-title">{ TRANSLATIONS.continueLearning() }</h5>
+                <div class="card-container full-width">
                     <Card
-                        each="{course in page.coursesCompleteLast}"
-                        if="{showCourse(course)}"
-                        status="{courseStatus(course)}"
-                        title="{course.title}"
-                        link="{course.loc_hash}"
-                        progress-value="{course.numberOfFinishedLessons}"
-                        progress-max="{course.numberOfLessons}"
-                        progressMax="{course.numberOfLessons}"
-                        imageUrl="{ course.cardImage }"
+                        status="{courseStatus(page.currentCourse)}"
+                        title="{page.currentCourse.title}"
+                        link="{page.currentCourse.loc_hash}"
+                        progressValue="{page.currentCourse.numberOfFinishedLessons}"
+                        progressMax="{page.currentCourse.numberOfLessons}"
+                        imageUrl="{ state.currentCourse.cardImage }"
                     ></Card>
                 </div>
-
-                <p if="{page.coursesCompleteLast.length === 0}">{ TRANSLATIONS.noCourses() }</p>
             </template>
+            <h5 class="section-title">{ TRANSLATIONS.allCourses() }</h5>
+            <div class="card-container">
+                <Card
+                    each="{course in page.coursesCompleteLast}"
+                    if="{showCourse(course)}"
+                    status="{courseStatus(course)}"
+                    title="{course.title}"
+                    link="{course.loc_hash}"
+                    progress-value="{course.numberOfFinishedLessons}"
+                    progress-max="{course.numberOfLessons}"
+                    progressMax="{course.numberOfLessons}"
+                    imageUrl="{ course.cardImage }"
+                ></Card>
+            </div>
+
+            <p if="{page.coursesCompleteLast.length === 0}">{ TRANSLATIONS.noCourses() }</p>
         </div>
     </div>
 
@@ -72,7 +70,6 @@
             state: {
                 currentCourse: null,
                 selectedTags: [],
-                sortedListOfCourses: null,
                 showTagList: false,
             },
 
@@ -91,9 +88,8 @@
             },
 
             showTagFilter() {
-                // we don't know the tags until the page data is available
                 // and we don't show the filter unless we have some tags
-                return this.page.ready && this.page.tags.length;
+                return  this.page.all_tags.size;
             },
 
             toggleTagList() {

--- a/src/riot/WagtailPages/AllTopicsPage.riot.html
+++ b/src/riot/WagtailPages/AllTopicsPage.riot.html
@@ -1,7 +1,7 @@
 <AllTopicsPage>
     <TopMenu extrastyleclasses="with-swoop">
         <h3>{ page.title }</h3>
-        <p>{ page.description }</p>
+        <p if="{ page.ready }">{ page.description }</p>
         <div class="filter-copy-container">
             <a
                 if="{showTagFilter()}"
@@ -13,23 +13,20 @@
         </div>
         <TagList
             if="{state.showTagList}"
-            tags="{state.listOfTags}"
+            tags="{ page.all_tags }"
             onTagClick="{onTagClick}"
             selectedTags="{state.selectedTags}"
         ></TagList>
     </TopMenu>
     <div class="content-wrapper">
-        <LoadingDots if="{!page.ready}" extrastyleclasses="dark"></LoadingDots>
-        <template if="{page.ready}">
-            <div class="card-container">
-                <Card
-                    each="{topic in page.childPages}"
-                    title="{topic.title}"
-                    link="{topic.loc_hash}"
-                    imageUrl="{topic.cardImage}"
-                ></Card>
-            </div>
-        </template>
+        <div class="card-container">
+            <Card
+                each="{topic in page.childPages}"
+                title="{topic.title}"
+                link="{topic.loc_hash}"
+                imageUrl="{topic.cardImage}"
+            ></Card>
+        </div>
     </div>
 
     <script>
@@ -44,19 +41,13 @@
             return {
                 state: {
                     showTagList: false,
-                    listOfTags: [],
                 },
                 onBeforeMount(props, state) {
                     this.page = getRoute().page;
                 },
                 showTagFilter() {
-                    // we don't know the tags until the page data is available
-                    // and we don't show the filter unless we have some tags
-                    return (
-                        this.page.ready &&
-                        this.page.tags &&
-                        this.page.tags.length
-                    );
+                    // we don't show the filter unless we have some tags
+                    return this.page.tags.size;
                 },
                 toggleTagList() {
                     this.update({ showTagList: !this.state.showTagList });

--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -12,29 +12,27 @@
         <div class="lesson-swoop">
 
             <h5 class="section-title">{ TRANSLATIONS.your_lessons() }</h5>
+            <div class="card-container">
+                <p if="{ !course.lessons.length }">{ TRANSLATIONS.no_lessons() }</h5>
+                <Card
+                    each="{lesson in course.lessons}"
+                    status="{lessonStatus(lesson)}"
+                    title="{lesson.title}"
+                    link="{lesson.loc_hash}"
+                    imageUrl="{lesson.imageUrl}"
+                ></Card>
+            </div>
             <LoadingDots if="{ !course.ready }" extrastyleclasses="dark"></LoadingDots>
-            <template if="{ course.ready }">
-                <div class="card-container">
-                    <p if="{ !course.lessons.length }">{ TRANSLATIONS.no_lessons() }</h5>
+            <template if="{ course.ready &&course.hasExam }">
+                <h5 class="section-title">{ TRANSLATIONS.course_exam() }</h5>
+                <div class="card-container full-width">
                     <Card
-                        each="{lesson in course.lessons}"
-                        status="{lessonStatus(lesson)}"
-                        title="{lesson.title}"
-                        link="{lesson.loc_hash}"
-                        imageUrl="{lesson.imageUrl}"
+                        title="{examTitle()}"
+                        description="{examDescription()}"
+                        link="{ `${course.loc_hash}:exam` }"
+                        status="{examStatus(course)}"
                     ></Card>
                 </div>
-                <template if="{ course.hasExam }">
-                    <h5 class="section-title">{ TRANSLATIONS.course_exam() }</h5>
-                    <div class="card-container full-width">
-                        <Card
-                            title="{examTitle()}"
-                            description="{examDescription()}"
-                            link="{ `${course.loc_hash}:exam` }"
-                            status="{examStatus(course)}"
-                        ></Card>
-                    </div>
-                </template>
             </template>
         </div>
     </div>

--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -19,11 +19,11 @@
                     status="{lessonStatus(lesson)}"
                     title="{lesson.title}"
                     link="{lesson.loc_hash}"
-                    imageUrl="{lesson.imageUrl}"
+                    imageUrl="{lesson.cardImage}"
                 ></Card>
             </div>
             <LoadingDots if="{ !course.ready }" extrastyleclasses="dark"></LoadingDots>
-            <template if="{ course.ready &&course.hasExam }">
+            <template if="{ course.ready && course.hasExam }">
                 <h5 class="section-title">{ TRANSLATIONS.course_exam() }</h5>
                 <div class="card-container full-width">
                     <Card

--- a/src/riot/WagtailPages/LearningActivityPage.riot.html
+++ b/src/riot/WagtailPages/LearningActivityPage.riot.html
@@ -1,0 +1,34 @@
+<LearningActivityPage>
+    <TopMenu extrastyleclasses="without-swoop">
+        <a class="top-icon left has-circle" href="{ `#${ activity.parent.loc_hash }` }">
+            <span class="arrow"></span>
+        </a>
+    </TopMenu>
+
+    <div class="content-wrapper">
+        <div>
+            <h2 id="coursePageTitle">{ activity.title }</h2>
+        </div>
+        <div class="lesson-swoop">
+        </div>
+    </div>
+
+    <script>
+        import TopMenu from "RiotTags/Components/TopMenu.riot.html";
+
+        import { getRoute } from "ReduxImpl/Interface";
+
+        function LearningActivityPage() { return {
+            onBeforeMount(props, state) {
+                this.activity = getRoute().page;
+            },
+
+        }};
+
+        LearningActivityPage.components = {
+            topmenu: TopMenu,
+        };
+
+        export default LearningActivityPage;
+    </script>
+</LearningActivityPage>

--- a/src/riot/WagtailPages/TopicPage.riot.html
+++ b/src/riot/WagtailPages/TopicPage.riot.html
@@ -1,0 +1,49 @@
+<TopicPage>
+    <TopMenu extrastyleclasses="without-swoop">
+        <a class="top-icon left has-circle" href="{ `#${ topic.parent.loc_hash }` }">
+            <span class="arrow"></span>
+        </a>
+    </TopMenu>
+
+    <div class="content-wrapper">
+        <div>
+            <h2 id="coursePageTitle">{ topic.title }</h2>
+        </div>
+        <div class="lesson-swoop">
+            <div class="card-container">
+                <p if="{ !topic.activities.length }">{ TRANSLATIONS.no_lessons() }</h5>
+                <Card
+                    each="{activity in topic.activities}"
+                    title="{activity.title}"
+                    link="{activity.loc_hash}"
+                    imageUrl="{activity.cardImage}"
+                ></Card>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        import Card from "RiotTags/Components/Card.riot.html";
+        import TopMenu from "RiotTags/Components/TopMenu.riot.html";
+
+        import { getRoute } from "ReduxImpl/Interface";
+
+        function TopicPage() { return {
+            TRANSLATIONS: {
+                no_activities: () => gettext("There are no activities yet in this topic"),
+            },
+
+            onBeforeMount(props, state) {
+                this.topic = getRoute().page;
+            },
+
+        }};
+
+        TopicPage.components = {
+            card: Card,
+            topmenu: TopMenu,
+        };
+
+        export default TopicPage;
+    </script>
+</TopicPage>

--- a/src/ts/Implementations/Specific/AllCourses.ts
+++ b/src/ts/Implementations/Specific/AllCourses.ts
@@ -2,16 +2,18 @@ import { Page } from "../Page";
 import Course from "./Course";
 
 export default class AllCourses extends Page {
-    #tags!: string[];
+    #all_tags!: Set<string>;
 
-    get tags(): string[] {
-        if (this.#tags === undefined) {
-            this.#tags = this.data.courses
-                .map((c: any) => c.tags)
-                .flat()
-                .map((tag: string) => tag.toLowerCase());
+    get all_tags(): Set<string> {
+        if (this.#all_tags === undefined) {
+            this.#all_tags = new Set(
+                this.courses
+                    .map((c: any) => c.tags)
+                    .flat()
+                    .map((tag: string) => tag.toLowerCase())
+            );
         }
-        return this.#tags;
+        return this.#all_tags;
     }
 
     get courses(): any {

--- a/src/ts/Implementations/Specific/Course.ts
+++ b/src/ts/Implementations/Specific/Course.ts
@@ -30,10 +30,6 @@ export default class Course extends Page {
     get examHighScore(): number {
         return getHighScore(this.slug);
     }
-    get allLessonsComplete(): boolean {
-        // NOT IMPLEMENTED
-        return true;
-    }
     get isExamFinished(): boolean {
         return ExamGrader.isExamFinished(this.slug);
     }

--- a/src/ts/Implementations/Specific/LearningActivity.ts
+++ b/src/ts/Implementations/Specific/LearningActivity.ts
@@ -1,7 +1,3 @@
 import { Page } from "../Page";
 
-export default class LearningActivity extends Page {
-    get resources(): Page[] {
-        return this.childPages;
-    }
-}
+export default class LearningActivity extends Page {}

--- a/src/ts/Implementations/Specific/LearningActivityRoot.ts
+++ b/src/ts/Implementations/Specific/LearningActivityRoot.ts
@@ -1,10 +1,22 @@
 import { Page } from "../Page";
 
 export default class LearningActivityRoot extends Page {
-    get resources(): Page[] {
+    #all_tags!: Set<string>;
+
+    get topics(): Page[] {
         return this.childPages;
     }
-
+    get all_tags(): Set<string> {
+        if (this.#all_tags === undefined) {
+            this.#all_tags = new Set(
+                this.topics
+                    .map((t: any) => t.tags)
+                    .flat()
+                    .map((tag: string) => tag.toLowerCase())
+            );
+        }
+        return this.#all_tags;
+    }
     get description(): string {
         return this.data.description;
     }

--- a/src/ts/Implementations/Specific/LearningActivityTopic.ts
+++ b/src/ts/Implementations/Specific/LearningActivityTopic.ts
@@ -1,7 +1,7 @@
 import { Page } from "../Page";
 
 export default class LearningActivityTopic extends Page {
-    get resources(): Page[] {
+    get activities(): Page[] {
         return this.childPages;
     }
 }

--- a/src/ts/Implementations/Specific/Resource.ts
+++ b/src/ts/Implementations/Specific/Resource.ts
@@ -5,10 +5,6 @@ export default class Resource extends Page {
         return this.data.description;
     }
 
-    get tags(): string[] {
-        return [];
-    }
-
     get cards(): any {
         return this.data.cards.cards;
     }

--- a/src/ts/Implementations/Specific/ResourcesRoot.ts
+++ b/src/ts/Implementations/Specific/ResourcesRoot.ts
@@ -1,7 +1,21 @@
 import { Page } from "../Page";
 
 export default class ResourcesRoot extends Page {
+    #all_tags!: Set<string>;
+
     get resources(): Page[] {
         return this.childPages;
+    }
+
+    get all_tags(): Set<string> {
+        if (this.#all_tags === undefined) {
+            this.#all_tags = new Set(
+                this.resources
+                    .map((r: any) => r.tags)
+                    .flat()
+                    .map((tag: string) => tag.toLowerCase())
+            );
+        }
+        return this.#all_tags;
     }
 }


### PR DESCRIPTION
Edits all of the list pages to instantly render their lists from the manifest data. Merging into @katevoss 's #511 for now

Sometimes this means there is no need for a loader, we may revisit that and show loaders for only the bits that do ( as in the course exam )

Also applies @megganeturner 's card images on Teaching/Learning list pages ( not resources yet )

PLan is to get both this and RC-2.0 up for review tomorrow morning