### PR TITLE
Add Teaching Topic page

### DIFF
--- a/src/js/AllCoursesList.js
+++ b/src/js/AllCoursesList.js
@@ -1,7 +1,7 @@
 import { _getOrFetchWagtailPageById } from "js/WagtailPagesAPI";
 import CoursePage from "./CoursePage";
 
-export default class AllCoursesPage {
+export default class AllCoursesList {
     constructor(aWagtailPage) {
         this.allCourses = aWagtailPage;
     }

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -108,9 +108,11 @@ export const isGuestUser = () => {
 };
 
 export const getUserId = () => {
-    return getUser().userId;
+    const user = getUser();
+    return user ? user.userId : null;
 };
 
 export const getUserGroups = () => {
-    return getUser().groups;
+    const user = getUser();
+    return user ? user.groups : null;
 };

--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -2,6 +2,12 @@ import { getLanguage } from "ReduxImpl/Interface";
 import { BACKEND_BASE_URL, MEDIA_PATH } from "js/urls";
 import { getOrFetchManifest } from "js/WagtailPagesAPI";
 
+import contentStockImg from "img/stock_content.png";
+import courseStockImg from "img/stock_course.png";
+import lessonStockImg from "img/stock_lesson.png";
+import objectiveStockImg from "img/stock_objective.png";
+import testStockImg from "img/stock_test.png";
+
 export const isCourseInTheCurrentLanguage = (courseSlug) => {
     const currentLanguage = getLanguage();
     switch (currentLanguage) {
@@ -80,4 +86,21 @@ export const getCourseWithLatestCompletion = (courses) => {
         lastWorkedOnCourse = course;
     }
     return lastWorkedOnCourse;
+};
+
+export const getCardImageUrl = (link, imageUrl) => {
+    const stockImages = [
+        contentStockImg,
+        courseStockImg,
+        lessonStockImg,
+        objectiveStockImg,
+        testStockImg,
+    ];
+    const cardId = typeof link === "number" ? link : link.split("/")[0];
+
+    const fallbackImg = stockImages[cardId % stockImages.length];
+
+    return imageUrl
+        ? `${process.env.API_BASE_URL}${imageUrl}?cardImageFallback=${fallbackImg}`
+        : fallbackImg;
 };

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -19,7 +19,7 @@
         <Profile if="{state.page.type === 'profile'}"></Profile>
         <Sync if="{state.page.type === 'sync'}"></Sync>
 
-        <AllCoursesPage if="{ state.page.type === 'homepage' }" ></AllCoursesPage>
+        <AllCoursesList if="{ state.page.type === 'homepage' }" ></AllCoursesList>
         <CourseOverview if="{ state.page.type === 'coursepage' }" ></CourseOverview>
         <LessonOverview
             if="{state.page.type === 'lessonpage'}"
@@ -31,7 +31,7 @@
         <ResourceArticle
             if="{state.page.type === 'resourcearticle'}"
         ></ResourceArticle>
-        <AllTopicsPage if="{ state.page.type === 'learningactivitieshomepage'}"></AllTopicsPage>
+        <AllTopicsList if="{ state.page.type === 'learningactivitieshomepage'}"></AllTopicsList>
 
         <BottomMenu page="{state.page}"></BottomMenu>
         <PushSubscription></PushSubscription>
@@ -56,11 +56,11 @@
         import ChangeBrowser from "RiotTags/Screens/ChangeBrowser.riot.html";
         import Sync from "RiotTags/Screens/Sync";
 
-        import AllCoursesPage from "RiotTags/WagtailPages/AllCoursesPage.riot.html";
+        import AllCoursesList from "RiotTags/WagtailPages/AllCoursesList.riot.html";
         import CourseOverview from "RiotTags/Lesson/CourseOverview.riot.html";
         import LessonOverview from "RiotTags/Lesson/LessonOverview.riot.html";
         import ResourceArticle from "RiotTags/WagtailPages/ResourceArticle.riot.html";
-        import AllTopicsPage from "RiotTags/WagtailPages/AllTopicsPage.riot.html";
+        import AllTopicsList from "RiotTags/WagtailPages/AllTopicsList.riot.html";
 
         function App() {
             function readState() {
@@ -70,6 +70,7 @@
                     riotHash: route.riotHash,
                     browserSupported: isBrowserSupported(),
                 };
+                console.log(state.page.type)
                 return state;
             }
             return {
@@ -94,7 +95,7 @@
             handleerror: HandleError,
             login: Login,
             bottommenu: BottomMenu,
-            allcoursespage: AllCoursesPage,
+            allcourseslist: AllCoursesList,
             courseoverview: CourseOverview,
             lessonoverview: LessonOverview,
             resources: Resources,
@@ -105,7 +106,7 @@
             changebrowser: ChangeBrowser,
             toast: Toast,
             resourcearticle: ResourceArticle,
-            alltopicspage: AllTopicsPage,
+            alltopicslist: AllTopicsList,
             loadingdots: LoadingDots,
         }
 

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -31,7 +31,8 @@
         <ResourceArticle
             if="{state.page.type === 'resourcearticle'}"
         ></ResourceArticle>
-        <AllTopicsList if="{ state.page.type === 'learningactivitieshomepage'}"></AllTopicsList>
+        <AllTopicsList if="{state.page.type === 'learningactivitieshomepage'}"></AllTopicsList>
+        <TopicPage if="{state.page.type === 'learningactivitytopicpage'}"></TopicPage>
 
         <BottomMenu page="{state.page}"></BottomMenu>
         <PushSubscription></PushSubscription>
@@ -61,6 +62,7 @@
         import LessonOverview from "RiotTags/Lesson/LessonOverview.riot.html";
         import ResourceArticle from "RiotTags/WagtailPages/ResourceArticle.riot.html";
         import AllTopicsList from "RiotTags/WagtailPages/AllTopicsList.riot.html";
+        import TopicPage from "RiotTags/Learning/TopicPage.riot.html";
 
         function App() {
             function readState() {
@@ -70,7 +72,6 @@
                     riotHash: route.riotHash,
                     browserSupported: isBrowserSupported(),
                 };
-                console.log(state.page.type)
                 return state;
             }
             return {
@@ -107,6 +108,7 @@
             toast: Toast,
             resourcearticle: ResourceArticle,
             alltopicslist: AllTopicsList,
+            topicpage: TopicPage,
             loadingdots: LoadingDots,
         }
 

--- a/src/riot/Components/Card.riot.html
+++ b/src/riot/Components/Card.riot.html
@@ -4,7 +4,7 @@
     </span>
     <a class="card {props.status}" href="#{props.link}">
         <div class="card-image">
-            <img crossorigin="anonymous" src="{getCardImageUrl()}" class="card-hero-image" />
+            <img crossorigin="anonymous" src="{getCardImage()}" class="card-hero-image" />
             <span class="card-status"><span class="icon"></span></span>
         </div>
         <div class="card-title">
@@ -18,25 +18,12 @@
         </div>
     </a>
     <script>
-        import contentStockImg from "img/stock_content.png";
-        import courseStockImg from "img/stock_course.png";
-        import lessonStockImg from "img/stock_lesson.png";
-        import objectiveStockImg from "img/stock_objective.png";
-        import testStockImg from "img/stock_test.png";
+        import {getCardImageUrl} from "js/utilities";
 
         export default {
-            getCardImageUrl() {
-                const stockImages = [contentStockImg, courseStockImg, lessonStockImg, objectiveStockImg, testStockImg];
-                const cardId = typeof this.props.link === 'number'
-                    ? this.props.link
-                    : this.props.link.split('/')[0];
-
-                const fallbackImg = stockImages[cardId % stockImages.length];
-
-                return this.props.imageUrl
-                    ? `${process.env.API_BASE_URL}${this.props.imageUrl}?cardImageFallback=${fallbackImg}`
-                    : fallbackImg;
-            },
+            getCardImage() {
+                return getCardImageUrl(this.props.link, this.props.imageUrl);
+            }
         };
     </script>
 </Card>

--- a/src/riot/Components/TopMenu.riot.html
+++ b/src/riot/Components/TopMenu.riot.html
@@ -4,4 +4,13 @@
             <slot />
         </div>
     </header>
+
+    <script>
+        export default {
+            onMounted() {
+                this.props.backgroundImage ? this.$(".top-menu-container").style.backgroundImage = `url(${this.props.backgroundImage})` : '';
+            },
+        };
+
+    </script>
 </TopMenu>

--- a/src/riot/Learning/LongCard.riot.html
+++ b/src/riot/Learning/LongCard.riot.html
@@ -1,0 +1,23 @@
+<LongCard>
+    <a class="long-card" href="#{props.link}">
+        <div class="card-image">
+            <img
+                crossorigin="anonymous"
+                src="{getCardImage()}"
+                class="card-hero-image"
+            />
+        </div>
+        <div class="card-title">
+            <h5>{props.title}</h5>
+        </div>
+    </a>
+    <script>
+        import { getCardImageUrl } from "js/utilities";
+
+        export default {
+            getCardImage() {
+                return getCardImageUrl(this.props.link, this.props.imageUrl);
+            },
+        };
+    </script>
+</LongCard>

--- a/src/riot/Learning/LongCard.riot.html
+++ b/src/riot/Learning/LongCard.riot.html
@@ -1,13 +1,15 @@
 <LongCard>
-    <a class="long-card" href="#{props.link}">
+    <a class="long-card {props.status}" href="#{props.link}">
         <div class="card-image">
             <img
                 crossorigin="anonymous"
                 src="{getCardImage()}"
                 class="card-hero-image"
             />
+            <span class="card-status"><span class="icon"></span></span>
         </div>
-        <div class="card-title">
+        <div class="card-text">
+            <p>Test231</p>
             <h5>{props.title}</h5>
         </div>
     </a>

--- a/src/riot/Learning/TopicPage.riot.html
+++ b/src/riot/Learning/TopicPage.riot.html
@@ -1,0 +1,47 @@
+<TopicPage>
+    <TopMenu
+        extrastyleclasses="with-swoop"
+        backgroundImage="{getCardImage(page.loc_hash, page.cardImage)}"
+    >
+        <a class="has-circle top-icon left" href="#topics">
+            <span class="arrow"></span>
+        </a>
+    </TopMenu>
+    <div class="content-wrapper">
+        <h3>{ page.title }</h3>
+        <p>{ page.description }</p>
+        <template if="{page.activities.length}">
+            <LongCard
+                each="{activity in page.activities}"
+                title="{activity.title}"
+                link="{activity.loc_hash}"
+                imageUrl="{activity.cardImage}"
+            ></LongCard>
+        </template>
+    </div>
+    <script>
+        import LongCard from "RiotTags/Learning/LongCard.riot.html";
+        import TopMenu from "RiotTags/Components/TopMenu.riot.html";
+        import { getRoute } from "ReduxImpl/Interface";
+        import { getCardImageUrl } from "js/utilities";
+
+        function TopicPage() {
+            return {
+                onBeforeMount(props, state) {
+                    this.page = getRoute().page;
+                },
+
+                getCardImage(link, cardImage) {
+                    return getCardImageUrl(link, cardImage);
+                },
+            };
+        }
+
+        TopicPage.components = {
+            topmenu: TopMenu,
+            longcard: LongCard,
+        };
+
+        export default TopicPage;
+    </script>
+</TopicPage>

--- a/src/riot/Learning/TopicPage.riot.html
+++ b/src/riot/Learning/TopicPage.riot.html
@@ -22,20 +22,19 @@
     <script>
         import LongCard from "RiotTags/Learning/LongCard.riot.html";
         import TopMenu from "RiotTags/Components/TopMenu.riot.html";
+
         import { getRoute } from "ReduxImpl/Interface";
         import { getCardImageUrl } from "js/utilities";
 
-        function TopicPage() {
-            return {
-                onBeforeMount(props, state) {
-                    this.page = getRoute().page;
-                },
+        function TopicPage() { return {
+			onBeforeMount(props, state) {
+				this.page = getRoute().page;
+			},
 
-                getCardImage(link, cardImage) {
-                    return getCardImageUrl(link, cardImage);
-                },
-            };
-        }
+			getCardImage(link, cardImage) {
+				return getCardImageUrl(link, cardImage);
+			},
+		}}
 
         TopicPage.components = {
             topmenu: TopMenu,

--- a/src/riot/Learning/TopicPage.riot.html
+++ b/src/riot/Learning/TopicPage.riot.html
@@ -16,6 +16,7 @@
                 title="{activity.title}"
                 link="{activity.loc_hash}"
                 imageUrl="{activity.cardImage}"
+                status="{isComplete(activity)}"
             ></LongCard>
         </template>
     </div>
@@ -34,6 +35,11 @@
 			getCardImage(link, cardImage) {
 				return getCardImageUrl(link, cardImage);
 			},
+
+            isComplete(activity) {
+                // return "complete";
+                return "in-complete";
+            }
 		}}
 
         TopicPage.components = {

--- a/src/riot/Screens/Profile.riot.html
+++ b/src/riot/Screens/Profile.riot.html
@@ -69,7 +69,7 @@
         import { getCapitalizedUsername, isGuestUser } from "js/AuthenticationUtilities";
         import { getCourseWithLatestCompletion } from "js/utilities";
 
-        import AllCoursesPage from "js/AllCoursesPage";
+        import AllCoursesList from "js/AllCoursesList";
 
         export default {
             state: {
@@ -99,10 +99,10 @@
 
             async onMounted() {
                 this.update({ loading: true });
-                const allCoursesPageJSON = await getHomePage();
-                const allCoursesPage = new AllCoursesPage(allCoursesPageJSON);
+                const allCoursesListJSON = await getHomePage();
+                const allCoursesList = new AllCoursesList(allCoursesListJSON);
 
-                let courses = await allCoursesPage.getFullCourseObjects();
+                let courses = await allCoursesList.getFullCourseObjects();
 
                 if (isGuestUser()) {
                     courses = courses.filter((course) => course.isVisibleToGuests());

--- a/src/riot/WagtailPages/AllCoursesList.riot.html
+++ b/src/riot/WagtailPages/AllCoursesList.riot.html
@@ -1,4 +1,4 @@
-<AllCoursesPage>
+<AllCoursesList>
     <div class="background">
         <GuestBanner></GuestBanner>
         <TopMenu extrastyleclasses="with-swoop">
@@ -68,7 +68,7 @@
 
         import { getRoute } from "ReduxImpl/Interface";
 
-        function AllCoursesPage() { return {
+        function AllCoursesList() { return {
             state: {
                 currentCourse: null,
                 selectedTags: [],
@@ -129,7 +129,7 @@
             },
         }};
 
-        AllCoursesPage.components = {
+        AllCoursesList.components = {
             card: Card,
             taglist: TagList,
             guestbanner: GuestBanner,
@@ -137,6 +137,6 @@
             topmenu: TopMenu,
         };
 
-        export default AllCoursesPage;
+        export default AllCoursesList;
     </script>
-</AllCoursesPage>
+</AllCoursesList>

--- a/src/riot/WagtailPages/AllCoursesList.riot.html
+++ b/src/riot/WagtailPages/AllCoursesList.riot.html
@@ -15,7 +15,7 @@
             </div>
             <TagList
                 if="{ state.showTagList }"
-                tags="{ page.tags }"
+                tags="{ page.all_tags }"
                 onTagClick="{onTagClick}"
                 selectedTags="{state.selectedTags}"
             ></TagList>
@@ -25,37 +25,35 @@
             <LoadingDots if="{!page.ready}"
                 extrastyleclasses="dark"
             ></LoadingDots>
-            <template if="{page.ready}">
-                <template if="{state.currentCourse && !state.currentCourse.isFinished()}">
-                    <h5 class="section-title">{ TRANSLATIONS.continueLearning() }</h5>
-                    <div class="card-container full-width">
-                        <Card
-                            status="{courseStatus(page.currentCourse)}"
-                            title="{page.currentCourse.title}"
-                            link="{page.currentCourse.loc_hash}"
-                            progressValue="{page.currentCourse.numberOfFinishedLessons}"
-                            progressMax="{page.currentCourse.numberOfLessons}"
-                            imageUrl="{ state.currentCourse.cardImage }"
-                        ></Card>
-                    </div>
-                </template>
-                <h5 class="section-title">{ TRANSLATIONS.allCourses() }</h5>
-                <div class="card-container">
+            <template if="{state.currentCourse && !state.currentCourse.isFinished()}">
+                <h5 class="section-title">{ TRANSLATIONS.continueLearning() }</h5>
+                <div class="card-container full-width">
                     <Card
-                        each="{course in page.coursesCompleteLast}"
-                        if="{showCourse(course)}"
-                        status="{courseStatus(course)}"
-                        title="{course.title}"
-                        link="{course.loc_hash}"
-                        progress-value="{course.numberOfFinishedLessons}"
-                        progress-max="{course.numberOfLessons}"
-                        progressMax="{course.numberOfLessons}"
-                        imageUrl="{ course.cardImage }"
+                        status="{courseStatus(page.currentCourse)}"
+                        title="{page.currentCourse.title}"
+                        link="{page.currentCourse.loc_hash}"
+                        progressValue="{page.currentCourse.numberOfFinishedLessons}"
+                        progressMax="{page.currentCourse.numberOfLessons}"
+                        imageUrl="{ state.currentCourse.cardImage }"
                     ></Card>
                 </div>
-
-                <p if="{page.coursesCompleteLast.length === 0}">{ TRANSLATIONS.noCourses() }</p>
             </template>
+            <h5 class="section-title">{ TRANSLATIONS.allCourses() }</h5>
+            <div class="card-container">
+                <Card
+                    each="{course in page.coursesCompleteLast}"
+                    if="{showCourse(course)}"
+                    status="{courseStatus(course)}"
+                    title="{course.title}"
+                    link="{course.loc_hash}"
+                    progress-value="{course.numberOfFinishedLessons}"
+                    progress-max="{course.numberOfLessons}"
+                    progressMax="{course.numberOfLessons}"
+                    imageUrl="{ course.cardImage }"
+                ></Card>
+            </div>
+
+            <p if="{page.coursesCompleteLast.length === 0}">{ TRANSLATIONS.noCourses() }</p>
         </div>
     </div>
 
@@ -72,7 +70,6 @@
             state: {
                 currentCourse: null,
                 selectedTags: [],
-                sortedListOfCourses: null,
                 showTagList: false,
             },
 
@@ -91,9 +88,8 @@
             },
 
             showTagFilter() {
-                // we don't know the tags until the page data is available
                 // and we don't show the filter unless we have some tags
-                return this.page.ready && this.page.tags.length;
+                return  this.page.all_tags.size;
             },
 
             toggleTagList() {

--- a/src/riot/WagtailPages/AllTopicsList.riot.html
+++ b/src/riot/WagtailPages/AllTopicsList.riot.html
@@ -13,61 +13,48 @@
         </div>
         <TagList
             if="{state.showTagList}"
-            tags="{state.listOfTags}"
+            tags="{page.all_tags}"
             onTagClick="{onTagClick}"
             selectedTags="{state.selectedTags}"
         ></TagList>
     </TopMenu>
     <div class="content-wrapper">
-        <LoadingDots if="{!page.ready}" extrastyleclasses="dark"></LoadingDots>
-        <template if="{page.ready}">
-            <div class="card-container">
-                <Card
-                    each="{topic in page.childPages}"
-                    title="{topic.title}"
-                    link="{topic.loc_hash}"
-                    imageUrl="{topic.cardImage}"
-                ></Card>
-            </div>
-        </template>
+        <div class="card-container">
+            <Card
+                each="{topic in page.childPages}"
+                title="{topic.title}"
+                link="{topic.loc_hash}"
+                imageUrl="{topic.cardImage}"
+            ></Card>
+        </div>
     </div>
 
     <script>
         import TopMenu from "RiotTags/Components/TopMenu.riot.html";
         import TagList from "RiotTags/Components/TagList.riot.html";
-        import LoadingDots from "RiotTags/Components/LoadingDots.riot.html";
         import Card from "RiotTags/Components/Card.riot.html";
 
         import { getRoute } from "ReduxImpl/Interface";
 
-        function AllTopicsList() {
-            return {
-                state: {
-                    showTagList: false,
-                    listOfTags: [],
-                },
-                onBeforeMount(props, state) {
-                    this.page = getRoute().page;
-                },
-                showTagFilter() {
-                    // we don't know the tags until the page data is available
-                    // and we don't show the filter unless we have some tags
-                    return (
-                        this.page.ready &&
-                        this.page.tags &&
-                        this.page.tags.length
-                    );
-                },
-                toggleTagList() {
-                    this.update({ showTagList: !this.state.showTagList });
-                },
-            };
-        }
+        function AllTopicsList() { return {
+            state: {
+                showTagList: false,
+            },
+            onBeforeMount(props, state) {
+                this.page = getRoute().page;
+            },
+            showTagFilter() {
+                // we don't show the filter unless we have some tags
+                return this.page.tags.size;
+            },
+            toggleTagList() {
+                this.update({ showTagList: !this.state.showTagList });
+            },
+        }}
 
         AllTopicsList.components = {
             topmenu: TopMenu,
             taglist: TagList,
-            loadingdots: LoadingDots,
             card: Card,
         };
 

--- a/src/riot/WagtailPages/AllTopicsList.riot.html
+++ b/src/riot/WagtailPages/AllTopicsList.riot.html
@@ -1,4 +1,4 @@
-<AllTopicsPage>
+<AllTopicsList>
     <TopMenu extrastyleclasses="with-swoop">
         <h3>{ page.title }</h3>
         <p>{ page.description }</p>
@@ -40,7 +40,7 @@
 
         import { getRoute } from "ReduxImpl/Interface";
 
-        function AllTopicsPage() {
+        function AllTopicsList() {
             return {
                 state: {
                     showTagList: false,
@@ -64,13 +64,13 @@
             };
         }
 
-        AllTopicsPage.components = {
+        AllTopicsList.components = {
             topmenu: TopMenu,
             taglist: TagList,
             loadingdots: LoadingDots,
             card: Card,
         };
 
-        export default AllTopicsPage;
+        export default AllTopicsList;
     </script>
-</AllTopicsPage>
+</AllTopicsList>

--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -19,7 +19,7 @@
                     status="{lessonStatus(lesson)}"
                     title="{lesson.title}"
                     link="{lesson.loc_hash}"
-                    imageUrl="{lesson.imageUrl}"
+                    imageUrl="{lesson.cardImage}"
                 ></Card>
             </div>
             <LoadingDots if="{ !course.ready }" extrastyleclasses="dark"></LoadingDots>

--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -12,29 +12,27 @@
         <div class="lesson-swoop">
 
             <h5 class="section-title">{ TRANSLATIONS.your_lessons() }</h5>
+            <div class="card-container">
+                <p if="{ !course.lessons.length }">{ TRANSLATIONS.no_lessons() }</h5>
+                <Card
+                    each="{lesson in course.lessons}"
+                    status="{lessonStatus(lesson)}"
+                    title="{lesson.title}"
+                    link="{lesson.loc_hash}"
+                    imageUrl="{lesson.imageUrl}"
+                ></Card>
+            </div>
             <LoadingDots if="{ !course.ready }" extrastyleclasses="dark"></LoadingDots>
-            <template if="{ course.ready }">
-                <div class="card-container">
-                    <p if="{ !course.lessons.length }">{ TRANSLATIONS.no_lessons() }</h5>
+            <template if="{ course.ready && course.hasExam }">
+                <h5 class="section-title">{ TRANSLATIONS.course_exam() }</h5>
+                <div class="card-container full-width">
                     <Card
-                        each="{lesson in course.lessons}"
-                        status="{lessonStatus(lesson)}"
-                        title="{lesson.title}"
-                        link="{lesson.loc_hash}"
-                        imageUrl="{lesson.imageUrl}"
+                        title="{examTitle()}"
+                        description="{examDescription()}"
+                        link="{ `${course.loc_hash}:exam` }"
+                        status="{examStatus(course)}"
                     ></Card>
                 </div>
-                <template if="{ course.hasExam }">
-                    <h5 class="section-title">{ TRANSLATIONS.course_exam() }</h5>
-                    <div class="card-container full-width">
-                        <Card
-                            title="{examTitle()}"
-                            description="{examDescription()}"
-                            link="{ `${course.loc_hash}:exam` }"
-                            status="{examStatus(course)}"
-                        ></Card>
-                    </div>
-                </template>
             </template>
         </div>
     </div>

--- a/src/scss/_all_courses.scss
+++ b/src/scss/_all_courses.scss
@@ -1,4 +1,4 @@
-AllCoursesPage {
+AllCoursesList {
     .background {
         background-color: $app-background-color;
     }

--- a/src/scss/_all_topics.scss
+++ b/src/scss/_all_topics.scss
@@ -1,4 +1,4 @@
-AllTopicsPage {
+AllTopicsList {
     .with-swoop {
         height: unset;
     }

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -86,7 +86,7 @@
     }
 }
 
-AllTopicsPage .card {
+AllTopicsList .card {
     .card-title .clamp-lines {
         height: unset;
     }

--- a/src/scss/_taglist.scss
+++ b/src/scss/_taglist.scss
@@ -34,8 +34,8 @@ TagList {
     }
 }
 
-AllCoursesPage TagList,
-AllTopicsPage TagList {
+AllCoursesList TagList,
+AllTopicsList TagList {
     .tag {
         border-radius: 50%;
         background-color: $gray-10;

--- a/src/scss/_top_menu.scss
+++ b/src/scss/_top_menu.scss
@@ -5,6 +5,8 @@ TopMenu {
         position: relative;
         max-width: $tablet;
         background-color: inherit;
+        background-size: cover;
+        background-position: center;
     }
 
     .with-swoop {

--- a/src/scss/_topic.scss
+++ b/src/scss/_topic.scss
@@ -3,33 +3,57 @@ TopicPage {
         height: 150px;
     }
 
-    LongCard .long-card {
-        width: 100%;
-        display: flex;
-        margin-top: 20px;
-        border-radius: 8px;
-        background-color: #ffffff;
-        box-shadow: 0 5px 10px 0 rgba(42, 57, 66, 0.2);
-		box-sizing: border-box;
-		height: 90px;
+    p.reference-text {
+        color: red;
+    }
+}
 
-        .card-image img {
+LongCard .long-card {
+    width: 100%;
+    display: flex;
+    margin-top: 20px;
+    border-radius: 8px;
+    background-color: #ffffff;
+    box-shadow: 0 5px 10px 0 rgba(42, 57, 66, 0.2);
+    box-sizing: border-box;
+    height: 90px;
+
+    &.complete .card-status {
+        @extend %absolutely-center;
+        @extend %status-complete;
+        border-radius: 50%;
+        width: 42px;
+        height: 42px;
+    }
+
+    .card-image {
+        position: relative;
+        
+        img {
             width: 90px;
             height: 90px;
             object-fit: cover;
             border-radius: 8px 0 0 8px;
         }
+    }
 
-		.card-title {
-			padding: 15px;
-			display: flex;
-			align-items: center;
+    .card-text {
+        padding: 12px 15px;
+        display: flex;
+        justify-content: center;
+        flex-direction: column;
 
-			h5 {
-				margin: 0;
-				color: $gray-1;
-				font-weight: 200;
-			}
-		}
+        p {
+            color: $gray-4;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        h5 {
+            margin: 0;
+            color: $gray-1;
+            font-weight: 200;
+        }
     }
 }

--- a/src/scss/_topic.scss
+++ b/src/scss/_topic.scss
@@ -1,0 +1,35 @@
+TopicPage {
+    TopMenu .with-swoop {
+        height: 150px;
+    }
+
+    .long-card {
+        width: 100%;
+        display: flex;
+        margin-top: 20px;
+        border-radius: 8px;
+        background-color: #ffffff;
+        box-shadow: 0 5px 10px 0 rgba(42, 57, 66, 0.2);
+		box-sizing: border-box;
+		height: 90px;
+
+        .card-image img {
+            width: 90px;
+            height: 90px;
+            object-fit: cover;
+            border-radius: 8px 0 0 8px;
+        }
+
+		.card-title {
+			padding: 15px;
+			display: flex;
+			align-items: center;
+
+			h5 {
+				margin: 0;
+				color: $gray-1;
+				font-weight: 200;
+			}
+		}
+    }
+}

--- a/src/scss/_topic.scss
+++ b/src/scss/_topic.scss
@@ -3,7 +3,7 @@ TopicPage {
         height: 150px;
     }
 
-    .long-card {
+    LongCard .long-card {
         width: 100%;
         display: flex;
         margin-top: 20px;

--- a/src/scss/canoe.scss
+++ b/src/scss/canoe.scss
@@ -23,6 +23,7 @@
 @import "login";
 @import "all_courses";
 @import "all_topics";
+@import "topic";
 @import "toast";
 @import "resources";
 @import "resource_article";

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -12,7 +12,7 @@ import Lesson from "./Specific/Lesson";
 import ResourcesRoot from "./Specific/ResourcesRoot";
 import Resource from "./Specific/Resource";
 import LearningActivityRoot from "./Specific/LearningActivityRoot";
-import LearningActivityTopic from "./Specific/LearningActivityTopic";
+import LearningTopic from "./Specific/LearningTopic";
 import LearningActivity from "./Specific/LearningActivity";
 
 import { MANIFEST_CACHE_NAME } from "../Constants";
@@ -241,12 +241,7 @@ export class Manifest extends PublishableItem<TManifestData> {
                     parent
                 );
             case "learningactivitytopicpage":
-                return new LearningActivityTopic(
-                    this,
-                    pageId,
-                    pageStatusId,
-                    parent
-                );
+                return new LearningTopic(this, pageId, pageStatusId, parent);
             case "learningactivitypage":
                 return new LearningActivity(this, pageId, pageStatusId, parent);
             default:

--- a/src/ts/Implementations/Specific/AllCourses.ts
+++ b/src/ts/Implementations/Specific/AllCourses.ts
@@ -2,16 +2,18 @@ import { Page } from "../Page";
 import Course from "./Course";
 
 export default class AllCourses extends Page {
-    #tags!: string[];
+    #all_tags!: Set<string>;
 
-    get tags(): string[] {
-        if (this.#tags === undefined) {
-            this.#tags = this.data.courses
-                .map((c: any) => c.tags)
-                .flat()
-                .map((tag: string) => tag.toLowerCase());
+    get all_tags(): Set<string> {
+        if (this.#all_tags === undefined) {
+            this.#all_tags = new Set(
+                this.courses
+                    .map((c: any) => c.tags)
+                    .flat()
+                    .map((tag: string) => tag.toLowerCase())
+            );
         }
-        return this.#tags;
+        return this.#all_tags;
     }
 
     get courses(): any {

--- a/src/ts/Implementations/Specific/Course.ts
+++ b/src/ts/Implementations/Specific/Course.ts
@@ -30,10 +30,6 @@ export default class Course extends Page {
     get examHighScore(): number {
         return getHighScore(this.slug);
     }
-    get allLessonsComplete(): boolean {
-        // NOT IMPLEMENTED
-        return true;
-    }
     get isExamFinished(): boolean {
         return ExamGrader.isExamFinished(this.slug);
     }

--- a/src/ts/Implementations/Specific/LearningActivity.ts
+++ b/src/ts/Implementations/Specific/LearningActivity.ts
@@ -1,7 +1,3 @@
 import { Page } from "../Page";
 
-export default class LearningActivity extends Page {
-    get resources(): Page[] {
-        return this.childPages;
-    }
-}
+export default class LearningActivity extends Page {}

--- a/src/ts/Implementations/Specific/LearningActivityRoot.ts
+++ b/src/ts/Implementations/Specific/LearningActivityRoot.ts
@@ -6,7 +6,7 @@ export default class LearningActivityRoot extends Page {
     get topics(): Page[] {
         return this.childPages;
     }
-    
+
     get all_tags(): Set<string> {
         if (this.#all_tags === undefined) {
             this.#all_tags = new Set(

--- a/src/ts/Implementations/Specific/LearningActivityRoot.ts
+++ b/src/ts/Implementations/Specific/LearningActivityRoot.ts
@@ -1,8 +1,22 @@
 import { Page } from "../Page";
 
 export default class LearningActivityRoot extends Page {
-    get resources(): Page[] {
+    #all_tags!: Set<string>;
+
+    get topics(): Page[] {
         return this.childPages;
+    }
+    
+    get all_tags(): Set<string> {
+        if (this.#all_tags === undefined) {
+            this.#all_tags = new Set(
+                this.topics
+                    .map((t: any) => t.tags)
+                    .flat()
+                    .map((tag: string) => tag.toLowerCase())
+            );
+        }
+        return this.#all_tags;
     }
 
     get description(): string {

--- a/src/ts/Implementations/Specific/LearningActivityTopic.ts
+++ b/src/ts/Implementations/Specific/LearningActivityTopic.ts
@@ -1,7 +1,0 @@
-import { Page } from "../Page";
-
-export default class LearningActivityTopic extends Page {
-    get resources(): Page[] {
-        return this.childPages;
-    }
-}

--- a/src/ts/Implementations/Specific/LearningTopic.ts
+++ b/src/ts/Implementations/Specific/LearningTopic.ts
@@ -1,0 +1,11 @@
+import { Page } from "../Page";
+
+export default class LearningTopic extends Page {
+    get activities(): Page[] {
+        return this.childPages;
+    }
+
+    get description(): string {
+        return this.data.description;
+    }
+}


### PR DESCRIPTION
Closes #456 

Also includes some commits from https://github.com/catalpainternational/canoe/pull/512

If you haven't yet, go to Wagtail to add a `Learning Activities Home`, then `Learning Activity Topic` as a child page, then `Learning Activity` as a child page of that. 

* Adds a Topic page with the list of activities in the topic. 
* The list of cards shows an image, the title, and a reference number. The reference number isn't yet editable.
* There is no "make offline" button or functionality, that's not in Release 1.
* There is a status complete circle and checkmark, which isn't functional. To view it, go to `isComplete(activity)` in `TopicPage.riot.html` in line 39, and uncomment line 40. 
      <img src="https://user-images.githubusercontent.com/2395211/110982294-5c016500-8336-11eb-84a2-dfdaacb39ae6.png" width="200">