### PR TITLE
447 course description fields

### DIFF
--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -1,13 +1,35 @@
 <CoursePage>
-    <TopMenu extrastyleclasses="without-swoop">
+    <TopMenu
+        extrastyleclasses="with-swoop"
+        backgroundImage="{getCardImage(course.loc_hash, course.cardImage)}"
+    >
         <a class="top-icon left has-circle" onclick="{backToAllCourses}">
             <span class="arrow"></span>
         </a>
     </TopMenu>
 
     <div class="content-wrapper">
-        <div>
+        <div class="course-details">
             <h2 id="coursePageTitle">{course.title}</h2>
+            <p if="{course.data.subtitle}" class="course-subtitle">
+                {course.data.subtitle}
+            </p>
+            <p>{course.data.short_description}</p>
+            <p if="{course.data.long_description && state.showLongDescription}">
+                {course.data.long_description}
+            </p>
+            <a
+                if="{course.data.long_description && state.showLongDescription}"
+                onclick="{toggleCourseDescription}"
+                >{ TRANSLATIONS.less() }
+                <span class="chevron down"></span>
+            </a>
+            <a
+                if="{course.data.long_description && !state.showLongDescription}"
+                onclick="{toggleCourseDescription}"
+                >{ TRANSLATIONS.more() }
+                <span class="chevron up"></span>
+            </a>
         </div>
         <div class="lesson-swoop">
 
@@ -44,13 +66,20 @@
         import TopMenu from "RiotTags/Components/TopMenu.riot.html";
 
         import { isAuthenticated, getRoute } from "ReduxImpl/Interface";
+        import { getCardImageUrl } from "js/utilities";
 
         function CoursePage() { return {
+            state: {
+                showLongDescription: false,
+            },
+
             TRANSLATIONS: {
                 no_lessons: () => gettext("There are no lessons yet in this course"),
                 your_lessons: () => gettext("Your lessons"),
                 course_exam: () => gettext("Course exam"),
                 highestScore: () => gettext("Highest score"),
+                more: () => gettext("See more"),
+                less: () => gettext("See less"),
             },
 
             onBeforeMount(props, state) {
@@ -68,6 +97,16 @@
                      ? `${this.TRANSLATIONS.highestScore()}: ${course.examHighScore}%`
                      : ''
                 );
+            },
+
+            toggleCourseDescription() {
+                this.update({
+                    showLongDescription: !this.state.showLongDescription,
+                });
+            },
+
+            getCardImage(link, cardImage) {
+                return getCardImageUrl(link, cardImage);
             },
 
             isExamEnabled() {

--- a/src/riot/WagtailPages/LessonPage.riot.html
+++ b/src/riot/WagtailPages/LessonPage.riot.html
@@ -30,14 +30,8 @@
         import { getRoute } from "ReduxImpl/Interface";
 
         function LessonPage() { return {
-            state: {
-                showLongDescription: false,
-            },
-
             TRANSLATIONS: {
                 lesson_activities: () => gettext("Lesson Activities"),
-                more: () => gettext("See more"),
-                less: () => gettext("See less"),
                 start: () => gettext("Start lesson"),
             },
 
@@ -59,12 +53,6 @@
 
             backToCoursePage() {
                 location.hash = "#" + this.lesson.course.loc_hash;
-            },
-
-            toggleLessonDescription() {
-                this.update({
-                    showLongDescription: !this.state.showLongDescription,
-                });
             },
 
             disableBlockedLessonModules() {

--- a/src/scss/_course.scss
+++ b/src/scss/_course.scss
@@ -5,7 +5,19 @@ CoursePage {
 
     .content-wrapper {
         h2 {
-            margin-bottom: 35px;
+            margin-bottom: 1em;
+        }
+
+        .course-subtitle {
+            color: $gray-3;
+            font-size: 1.2em;
+            margin: 1em 0;
+            width: 100%;
+            line-height: 1.6em;
+        }
+
+        .course-details {
+            margin-bottom: 2em;
         }
     }
 }

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -128,10 +128,6 @@ ResourceArticle LessonFrame {
         display: flex;
     }
 
-    .lesson-description:last-of-type {
-        margin-bottom: 0.7em;
-    }
-
     raw,
     basiccard,
     quotecard,

--- a/src/scss/_resource_article.scss
+++ b/src/scss/_resource_article.scss
@@ -17,7 +17,7 @@ ResourceArticle {
         margin-top: 20px;
     }
 
-    .content .resource-description {
+    .resource-description {
         color: $gray-1;
         font-size: 1.2em;
         margin: 1em 0;


### PR DESCRIPTION
Closes #447 

Adds course description (long & short) to course overview page
+ also added the card image

You'll need https://github.com/catalpainternational/canoe-backend/pull/116 in the backend to see these fields come through

![Screen Shot 2021-03-19 at 1 38 10 pm](https://user-images.githubusercontent.com/12974326/111724217-f9214800-88b8-11eb-9a7b-11a32386bbb5.png)
