### PR TITLE
522 error after replacing image

### DIFF
--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -48,8 +48,11 @@ async function route(hashWith) {
     try {
         manifest = await getValidManifest();
     } catch (err) {
+        // This can be caused by there being 'no manifest found'
+        // However, it's normally caused by bugs in riot tags,
+        // when a change was made elsewhere but not followed through into the tag
         // Note that this may leak information that we don't want leaked
-        setRoute({type: "error", error: `No manifest found. Error: ${err}`});
+        setRoute({type: "error", error: `There was a problem preparing the page to show to you. Error: ${err}`});
         return;
     }
 

--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -1,30 +1,44 @@
 <ImageWrapper>
     <img
         if="{state.imagePath}"
-        alt="{props.image.alt}"
+        alt="{state.image.alt}"
         class="richtext-image"
         crossorigin="anonymous"
         src="{state.imagePath}"
     />
     <p class="error-message" if="{!state.imagePath}">
-        Error: image "{props.image.alt}", is missing.
+        Sorry: image "{state.image.alt}", is missing.
     </p>
 
     <script>
         import { getRoute } from "ReduxImpl/Interface";
         import { getRenditionUrl } from "js/RenditionSelector";
+        import { MissingImageError } from "js/Errors";
 
         export default {
             state: {
                 imagePath: "",
+                image: {
+                    id: "unknown",
+                    alt: "Unknown Image",
+                }
             },
 
             onBeforeMount(props, state) {
                 this.page = getRoute().page;
+                this.state.image = props.image;
                 const asset = this.page.PETEgetImageRenditions(
                     props.image.id
                 );
-                this.state.imagePath = getRenditionUrl(asset.renditions);
+                if (asset) {
+                    try {
+                        this.state.imagePath = getRenditionUrl(asset.renditions);
+                    } catch (error) {
+                        if (error instanceof MissingImageError) {
+                            this.state.imagePath = "";
+                        }
+                    }
+                }
             },
         };
     </script>


### PR DESCRIPTION
# Description

This makes `ImageWrapper` riot tag more robust, and cleans up the text of the error message in routing that confuses us all.

This does not fix the fact that `routing` sets the route to `error` and there's no riot tag to respond to that route...

There is an underlying issue of images having renditions generated when they are loaded up via wagtail admin, and yet those renditions are not what we need in the front end (as defined via the manifest).  These are canoe-backend problems.