### PR TITLE
Configurable landing experience & intelligent bottom menu

### DIFF
--- a/canoe-project-default.js
+++ b/canoe-project-default.js
@@ -15,5 +15,8 @@ module.exports = {
     SITE_NAME: "Canoe",
     SITE_SHORT_NAME: "Canoe",
     SITE_DESCRIPTION: "An online education platform",
-    FAVICON_PATH: "./src/favicon.svg"
+    FAVICON_PATH: "./src/favicon.svg",
+    // If true REQUIRE_LOGIN will always redirect any user who does not have a login to the login page
+    // unless they have a manifest cache in place already
+    REQUIRE_LOGIN: false
 };

--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -1,13 +1,16 @@
-import { getLanguage, setRoute } from "ReduxImpl/Interface";
+import { getLanguage, setRoute, isAuthenticated } from "ReduxImpl/Interface";
 import { logPageView } from "js/GoogleAnalytics";
 
 import { InitialiseByRequest } from "ts/Implementations/CacheItem";
 import { Manifest } from "ts/Implementations/Manifest";
 
-// pages that are rendered by the application, and do not require a manifest
-const CANOE_PAGES = ['login', 'settings'];
-// pages that are rendered by the application, and do require a manifest
-const CANOE_MANIFEST_PAGES = ['profile', 'sync'];
+// If true REQUIRE_LOGIN will always redirect any user who does not have a login to the login page
+// unless they have a manifest cache in place already
+const REQUIRE_LOGIN = process.env.REQUIRE_LOGIN;
+
+const LOGIN_ROUTE = 'login';
+// pages that are rendered by the application
+const CANOE_PAGES = ['settings', 'profile', 'sync'];
 // pages that are shortcuts into a CMS page ( e.g. resources goes to the selected language resource root )
 const CANOE_SHORTCUTS = {
     "": "homepage",
@@ -15,9 +18,6 @@ const CANOE_SHORTCUTS = {
     resources: "resourcesroot",
     topics: "learningactivitieshomepage",
 };
-
-// pages from the CMS ( we might not use this )
-const IS_WAGTAIL_PAGE = /([\d]+)/; // should match '#3' and '#3/objectives'
 
 const IS_PAGE_PREVIEW = /^\?(.+)/;
 
@@ -35,43 +35,49 @@ async function route(hashWith) {
     const riotHash = hashParts.slice(1);
     let page = undefined;
     let manifest = undefined;
+    let route = undefined;
 
     logPageView(hash);
 
-    // If we are a simple canoe page all should be good
-    if(CANOE_PAGES.includes(pageHash)) {
-        setRoute({type: pageHash}, riotHash);
-        return;
-    }
-
-    // otherwise we need a manifest to understand what to render
-    try {
-        manifest = await getValidManifest();
-    } catch (err) {
-        // This can be caused by there being 'no manifest found'
-        // However, it's normally caused by bugs in riot tags,
-        // when a change was made elsewhere but not followed through into the tag
-        // Note that this may leak information that we don't want leaked
-        setRoute({type: "error", error: `There was a problem preparing the page to show to you. Error: ${err}`});
-        return;
-    }
-
-    if(CANOE_MANIFEST_PAGES.includes(pageHash)) {
-        page = manifest.getLanguagePageType(getLanguage(), 'homepage');
-        setRoute({type: pageHash, home:page}, riotHash);
-        return;
-    }
-
-    // If we are a shortcut get the page from the manifest
-    if(Object.keys(CANOE_SHORTCUTS).includes(pageHash)) {
-        page = manifest.getLanguagePageType(getLanguage(), CANOE_SHORTCUTS[pageHash]);
+    if(pageHash === LOGIN_ROUTE) {
+        // If we are a simple canoe page all should be good
+        route = {page: {type: LOGIN_ROUTE}, riotHash};
     } else {
-        page = manifest.getPageManifestData(pageHash);
+        // otherwise we need a manifest ( bottom nav always needs to know )
+        try {
+            manifest = await getValidManifest();
+        } catch (err) {
+            route = {page: {type: "manifest_error", error: `Manifest retrieval failure. Error: ${err}`}};
+        }
+        
+        if( !isAuthenticated() && REQUIRE_LOGIN )
+        { 
+            // if the site is configured to require login and we are not logged in, show the login page 
+            window.location.hash = `#${LOGIN_ROUTE}`;
+            return;
+        }
+
+        if(CANOE_PAGES.includes(pageHash)) {
+            // If we are a canoe page that needs page data, get it
+            page = manifest.getLanguagePageType(getLanguage(), 'homepage');
+            route = {page: {type: pageHash, home:page, manifest: manifest}, riotHash};
+        } else {
+            if(Object.keys(CANOE_SHORTCUTS).includes(pageHash)) {
+                // If we are a shortcut get the first page of that type from the manifest
+                page = manifest.getLanguagePageType(getLanguage(), CANOE_SHORTCUTS[pageHash]);
+            } else {
+                // If we are a shortcut get the first page of that type from the manifest
+                page = manifest.getPageManifestData(pageHash);
+            }
+            route = {page, riotHash};
+            // refresh the page
+            if (!page.ready) {
+                InitialiseByRequest(page);
+            }
+        }
     }
-    if (!page.ready) {
-        InitialiseByRequest(page);
-    }
-    setRoute(page, riotHash);
+
+    setRoute(route);
 }
 
 async function getValidManifest() {

--- a/src/js/redux/Interface.js
+++ b/src/js/redux/Interface.js
@@ -119,8 +119,8 @@ export const setUnauthenticated = () => {
     store.dispatch(setUnAuthenticatedState());
 };
 
-export const setRoute = (route, riotHash) => {
-    store.dispatch(setCanoePage(route, riotHash));
+export const setRoute = (route) => {
+    store.dispatch(setCanoePage(route.page, route.riotHash));
 };
 
 export const getRoute = () => {

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -35,7 +35,7 @@
         <TopicPage if="{state.page.type === 'learningactivitytopicpage'}"></TopicPage>
         <ActivityPage if="{state.page.type === 'learningactivitypage'}"></ActivityPage>
 
-        <BottomMenu page="{state.page}"></BottomMenu>
+        <BottomMenu></BottomMenu>
         <PushSubscription></PushSubscription>
     </template>
 

--- a/src/riot/Components/BottomMenu.riot.html
+++ b/src/riot/Components/BottomMenu.riot.html
@@ -1,24 +1,24 @@
 <BottomMenu>
     <footer if="{showBottomMenu()}">
         <div class="bottom-menu">
-            <a href="#">
-                <span class="all-courses-icon { props.page.type === 'homepage' ? 'active' : ''}">
+            <a href="#" if="{shouldShowLearningHome()}">
+                <span class="all-courses-icon { page.type === 'homepage' ? 'active' : ''}">
                 </span>
             </a>
             <a href="#profile">
-                <span class="profile-icon { props.page.type === 'profile' ? 'active' : ''}">
+                <span class="profile-icon { page.type === 'profile' ? 'active' : ''}">
                 </span>
             </a>
-            <a href="#resources">
-                <span class="resources-icon { props.page.type === 'resourcesroot' ? 'active' : ''}">
+            <a href="#resources" if="{shouldShowResources()}">
+                <span class="resources-icon { page.type === 'resourcesroot' ? 'active' : ''}">
                 </span>
             </a>
             <a href="#sync" if="{shouldShowSync()}">
-                <span class="resources-icon { props.page.type === 'sync' ? 'active' : ''}">
+                <span class="resources-icon { page.type === 'sync' ? 'active' : ''}">
                 </span>
             </a>
-            <a href="#topics" if="{true}">
-                <span class="list-icon { props.page.type === 'learningactivitieshomepage' ? 'active' : ''}">
+            <a href="#topics" if="{shouldShowTeachingHome()}">
+                <span class="list-icon { page.type === 'learningactivitieshomepage' ? 'active' : ''}">
                 </span>
             </a>
         </div>
@@ -28,34 +28,44 @@
         import { getRoute } from "ReduxImpl/Interface";
         import { inAppelflap } from "ts/PlatformDetection";
 
-        function getState() {
-            const route = getRoute();
-            return {
-                section: route.riotHash ? route.riotHash[0] : ""
-            }
-        }
         export default {
-            state: getState(),
+            onBeforeMount() {
+                this.page = getRoute().page;
+                this.riotHash = getRoute().riotHash;
+            },
 
+            onBeforeUpdate() {
+                this.page = getRoute().page;
+                this.riotHash = getRoute().riotHash;
+            },
             shouldShowSync() {
                 return inAppelflap();
             },
+            shouldShowLearningHome() {
+                return this.page.manifest.hasPageType('homepage');
+            },
+            shouldShowTeachingHome() {
+                return this.page.manifest.hasPageType('learnignactivityhomepage');
+            },
+            shouldShowResources() {
+                return this.page.manifest.hasPageType('resourcesroot');
+            },
+
             showBottomMenu() {
-                if (this.props.page.type === 'lessonpage') {
+                if (this.page.type === 'initial') {
                     return false;
                 }
-                if (this.props.page.type === 'coursepage' && this.state.section) {
+                if (this.page.type === 'login') {
+                    return false;
+                }
+                if (this.page.type === 'lessonpage') {
+                    return false;
+                }
+                if (this.page.type === 'coursepage' && !this.riotHash) {
                     return false;
                 }
                 return true;
             },
-
-            storeListener(previousStoreState, storeState) {
-                const newState = getState();
-                if (this.state.section !== newState.section) {
-                    this.update(newState);
-                }
-            }
         };
     </script>
 </BottomMenu>

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -257,4 +257,12 @@ export class Manifest extends PublishableItem<TManifestData> {
 
         return pageId ? this.getSpecificPage(pageId) : undefined;
     }
+
+    hasPageType(pageType: string): boolean {
+        return Object.values(this.data.pages)
+            .map((p: TWagtailPage) => {
+                return p.type;
+            })
+            .includes(pageType);
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = env => {
         },
         {}
     );
+    processEnvironment["process.env.REQUIRE_LOGIN"] = projectConfiguration.REQUIRE_LOGIN;
     processEnvironment["process.env.SITE_NAME"] = JSON.stringify(
         projectConfiguration.SITE_NAME
     );


### PR DESCRIPTION
Some projects need to require login, they have no desire to allow guests to browse content
All projects should only show bottom menu bars that actually have content

- Introduces a REQUIRE_LOGIN project config attribute
  - when `true` this will redirect the user to login if not authenticated
  - when `false` this will show the content that is available to unauthenticated users ( with the Login Banner )

- [ ] behaviour in appelflap still to be decided ( use `REQUIRE_LOGIN: false` for now )

This also means the missing manifest error is actually a missing manifest error!