### PR TITLE
528 pre learning survey

### DIFF
--- a/src/riot/Lesson/CourseExam.riot.html
+++ b/src/riot/Lesson/CourseExam.riot.html
@@ -109,22 +109,38 @@
                 this.state.stage = stage;
                 this.state.examType = examType;
 
-                // TODO actually I believe we want to remove the randomisation & trancation all together, for exams && pre-learning surveys
-                if (examType === 'prelearning' && this.course.ready) {
-                    this.state.cards = this.course.examCards;
-                } else if (this.state.cards === undefined && this.course.ready) {
-                    this.state.cards = this.shuffleCards(this.course.examCards).slice(0, 5);
-                }
-                if (this.state.cards && !isNaN(this.state.cardNumber)) {
-                    this.state.card = this.state.cards[this.state.cardNumber - 1];
-                    if (examType === 'prelearning') {
-                        this.state.cardAnswers = this.state.card.answers;
-                    } else {
-                        this.state.cardAnswers = this.shuffleCards(this.state.card.answers);
+                // TODO this may become a project config attribute, pending further discussion
+                let randomize_and_limit = true;
+                if (examType === 'prelearning') randomize_and_limit = false;
+
+
+                if (randomize_and_limit && this.course.ready) {
+                    // randomise & limit the cards
+                    if (this.state.cards === undefined && this.course.ready) {
+                        this.state.cards = this.shuffleCards(this.course.examCards).slice(0, 5);
                     }
 
-                    if (!this.state.currentAnswer) {
-                        this.state.currentAnswer = ExamGrader.loadExamAnswer(this.state.card.id) || {};
+                    if (this.state.cards && !isNaN(this.state.cardNumber)) {
+                        this.state.card = this.state.cards[this.state.cardNumber - 1];
+                        this.state.cardAnswers = this.shuffleCards(this.state.card.answers);
+
+
+                        if (!this.state.currentAnswer) {
+                            this.state.currentAnswer = ExamGrader.loadExamAnswer(this.state.card.id) || {};
+                        }
+                    }
+
+                } else if (this.course.ready) {
+                    // do not randomise & limit the cards
+                    this.state.cards = this.course.examCards;
+
+                    if (this.state.cards && !isNaN(this.state.cardNumber)) {
+                        this.state.card = this.state.cards[this.state.cardNumber - 1];
+                        this.state.cardAnswers = this.state.card.answers;
+
+                        if (!this.state.currentAnswer) {
+                            this.state.currentAnswer = ExamGrader.loadExamAnswer(this.state.card.id) || {};
+                        }
                     }
                 }
             },

--- a/src/riot/Lesson/CourseExam.riot.html
+++ b/src/riot/Lesson/CourseExam.riot.html
@@ -3,7 +3,7 @@
         <HonorCode minimumScore="{ MINIMUM_SCORE }"></HonorCode>
     </LessonFrame>
     <LessonFrame
-        if="{ !isNaN(state.cardNumber) }"
+        if="{ !isNaN(state.cardNumber) && course.ready }"
         id="test"
         extraStyleClasses="test"
         linkTo="{ course.loc_hash }"
@@ -28,7 +28,7 @@
             savedAnswer="{state.currentAnswer.answers}"
         ></TestMultipleAnswer>
     </LessonFrame>
-    <div if="{ !isNaN(state.cardNumber) }" class="bottom-buttons">
+    <div if="{ !isNaN(state.cardNumber) && course.ready }" class="bottom-buttons">
         <div>
             <a if="{state.cardNumber > 1}" class="has-circle" onclick="{previousExamCard}">
                 <span class="arrow"></span>
@@ -59,6 +59,7 @@
         title="{ course.title }"
         finalScore="{calculateFinalScore()}"
         minimumScore="{MINIMUM_SCORE}"
+        examType="{state.examType}"
     ></ExamResults>
 
     <script>
@@ -98,17 +99,30 @@
             SECTION: "exam",
 
             readState() {
-                const route = getRoute()
-                const stage = route.riotHash[1] || 'code';
+                const route = getRoute();
+                const examType = this.course.data.exam_type;
+                // Don't show the honor code if it's a pre-learning exam
+                const fallbackStage = examType === 'prelearning' ? 1 : 'code';
+                const stage = route.riotHash[1] || fallbackStage;
                 const cardNumber = parseInt(stage);
                 this.state.cardNumber = cardNumber;
                 this.state.stage = stage;
-                if (this.state.cards === undefined && this.course.ready) {
+                this.state.examType = examType;
+
+                // TODO actually I believe we want to remove the randomisation & trancation all together, for exams && pre-learning surveys
+                if (examType === 'prelearning' && this.course.ready) {
+                    this.state.cards = this.course.examCards;
+                } else if (this.state.cards === undefined && this.course.ready) {
                     this.state.cards = this.shuffleCards(this.course.examCards).slice(0, 5);
                 }
                 if (this.state.cards && !isNaN(this.state.cardNumber)) {
                     this.state.card = this.state.cards[this.state.cardNumber - 1];
-                    this.state.cardAnswers = this.shuffleCards(this.state.card.answers);
+                    if (examType === 'prelearning') {
+                        this.state.cardAnswers = this.state.card.answers;
+                    } else {
+                        this.state.cardAnswers = this.shuffleCards(this.state.card.answers);
+                    }
+
                     if (!this.state.currentAnswer) {
                         this.state.currentAnswer = ExamGrader.loadExamAnswer(this.state.card.id) || {};
                     }

--- a/src/riot/Lesson/ExamResults.riot.html
+++ b/src/riot/Lesson/ExamResults.riot.html
@@ -1,7 +1,7 @@
 <ExamResults>
     <template if="{state.passedExam !== null}">
         <div class="congratulations-container">
-            <template if="{state.passedExam}">
+            <template if="{state.passedExam || props.examType === 'prelearning'}">
                 <span class="superman-success"></span>
                 <h2>{ TRANSLATIONS.success() }</h2>
                 <h3>{ TRANSLATIONS.completed() }</h3>
@@ -13,7 +13,7 @@
                     { TRANSLATIONS.resources() }
                 </button>
             </template>
-            <template if="{!state.passedExam}">
+            <template if="{!state.passedExam && props.examType !== 'prelearning'}">
                 <div>
                     <span class="incorrect-cross"></span>
                     <h2>{ TRANSLATIONS.notQuite() }</h2>
@@ -76,6 +76,12 @@
 
             passedExamMessage() {
                 // message when user passed the exam
+                if (this.props.examType === 'prelearning') {
+                    return gettext(
+                        "You have completed the pre-learning survey and you can now keep progressing your learning."
+                    )
+                }
+
                 return gettext(
                     "You passed this exam with a score of %1%. If you want to improve your score you can retake this exam.",
                     this.props.finalScore

--- a/src/riot/Lesson/LessonComplete.riot.html
+++ b/src/riot/Lesson/LessonComplete.riot.html
@@ -17,7 +17,11 @@
                 <p>{ lessonCompleteMessage() }</p>
                 <p if="{ courseHasExam() }">{ takeCourseExamMessage() }</p>
             </div>
-            <button if="{ courseHasExam() }" class="btn-primary" onclick="{goToCourseExam}">
+            <button if="{courseHasExam() && isPrelearningExam()}" class="btn-primary" onclick="{goToCourseExam}">
+                { TRANSLATIONS.survey() }
+                <span class="chevron"></span>
+            </button>
+            <button if="{courseHasExam() && !isPrelearningExam()}" class="btn-primary" onclick="{goToCourseExam}">
                 { TRANSLATIONS.exam() }
                 <span class="chevron"></span>
             </button>
@@ -38,15 +42,21 @@
                 next: () => gettext("Next Lesson"),
                 good: () => gettext("Good job!"),
                 exam: () => gettext("Take Exam"),
+                survey: () => gettext("Take Survey"),
                 course: () => gettext("Back to Course"),
             },
 
             courseHasExam() {
-                return this.state.lesson.course.has_exam;
+                return this.state.lesson.course.hasExam;
+            },
+
+            isPrelearningExam() {
+                return this.state.lesson.course.data.exam_type === 'prelearning';
             },
 
             isCourseComplete() {
-                return this.state.lesson.course.allLessonsComplete;
+                return this.state.lesson.course.numberOfLessons
+                    === this.state.lesson.course.numberOfFinishedLessons;
             },
 
             goToCourseOverview() {
@@ -64,6 +74,13 @@
 
             takeCourseExamMessage() {
                 // message on completion of lesson and prompt to take course exam
+                if (this.isPrelearningExam()) {
+                    return gettext(
+                        'Take the pre-learning survey to complete the course "%1"',
+                        this.state.lesson.course.title
+                    )
+                }
+
                 return gettext(
                     'Take the exam now to complete the course "%1"',
                     this.state.lesson.course.title

--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -112,7 +112,8 @@
             isExamEnabled() {
                 // Exams are enabled if you complete all lessons or if you are a
                 // guest user.
-                return this.course.allLessonsComplete || !isAuthenticated();
+                return this.course.numberOfLessons === this.course.numberOfFinishedLessons
+                    || !isAuthenticated();
             },
 
             examTitle() {


### PR DESCRIPTION
Closes #528 

Still awaiting a couple of translations, will push them as soon as I have them (:

We're now getting an attribute `exam_type` on courses, which will come through as either 'exam' or 'prelearning'. Based on the type, we render slightly different things:

- hide honor code for exams with 'prelearning' type
- slightly modifies the copy on lesson completion & exam results screens
- prelearning exams do not use the shuffle/limit logic: we render all of the cards, in order
  - this condition could become an environment variable set in the config, as it may vary project to project (for example, JID don't want shuffling/limiting for prelearning surveys or regular exams, but Maluk do)

<img src="https://user-images.githubusercontent.com/12974326/112086315-1703eb00-8be0-11eb-805d-ccb2d291a6df.png" width="250">
<img src="https://user-images.githubusercontent.com/12974326/112086312-14a19100-8be0-11eb-9062-17f178b7bdf1.png" width="250">
