### PR TITLE
make lesson card images full width

### DIFF
--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -223,8 +223,14 @@ ResourceArticle LessonFrame {
     }
 
     img.richtext-image {
-        margin: 1em 0;
-        width: 100%;
+        width: calc(100% + (2 * 20px));
+        margin-left: -20px;
+        margin-right: -20px;
+    }
+
+    basiccard img.richtext-image {
+        margin-top: -30px;
+        border-radius: 8px 8px 0 0;
     }
 
     h3.media-title {

--- a/src/scss/_resource_article.scss
+++ b/src/scss/_resource_article.scss
@@ -9,6 +9,8 @@ ResourceArticle {
             width: calc(100% + (2 * 22px));
             margin-left: -22px;
             margin-right: -22px;
+            border-radius: 0;
+            margin-top: unset;
         }
     }
 


### PR DESCRIPTION
Closes #464

Small change to make images full-width on lesson cards

![Screen Shot 2021-03-23 at 3 16 21 pm](https://user-images.githubusercontent.com/12974326/112092461-a367db00-8beb-11eb-803e-28182383b8e1.png)
