### PR TITLE
Multi choice state fix

### DIFF
--- a/src/riot/Lesson/CourseExam.riot.html
+++ b/src/riot/Lesson/CourseExam.riot.html
@@ -1,5 +1,5 @@
 <CourseExam>
-    <LessonFrame if="{ state.stage === 'code' }" linkTo="{ course.loc_hash }">
+    <LessonFrame if="{ state.stage === 'code' && state.examType !== 'prelearning'}" linkTo="{ course.loc_hash }">
         <HonorCode minimumScore="{ MINIMUM_SCORE }"></HonorCode>
     </LessonFrame>
     <LessonFrame

--- a/src/riot/Lesson/TestMultipleAnswer.riot.html
+++ b/src/riot/Lesson/TestMultipleAnswer.riot.html
@@ -63,6 +63,9 @@
                 const { savedAnswer } = this.props;
 
                 if (!savedAnswer) {
+                    this.update({
+                        hiddenAnswers: [],
+                    })
                     return;
                 }
 
@@ -89,6 +92,7 @@
                 if (isQuestionComplete) {
                     this.update({
                         visibleAnswers: [],
+                        hiddenAnswers: [],
                     });
                 }
             },


### PR DESCRIPTION
Previously when there were multiple multi-choice questions in a lesson/exam, the state wasn't being reset correctly between them and the answers stored in state for question B were actually the answers from question A. This should resolve that by explicitly resetting the `hiddenAnswers` attribute.

Also a small addition to the course exam page to prevent the honor code flashing up on screen while the calculations were being done for the route.