### PR TITLE
Fix other item in manifest cache

### DIFF
--- a/src/ts/Implementations/CacheItem.ts
+++ b/src/ts/Implementations/CacheItem.ts
@@ -92,7 +92,7 @@ const CleanRequestObject = (item: IPublishableItem, srcReq: Request): void => {
 const GetRequestObject = async (
     item: IPublishableItem
 ): Promise<Request | undefined> => {
-    if (!item.fullUrl) {
+    if (!item.fullUrl || item.fullUrl === "/") {
         // "The full url could not be determined for this item, it is not retrievable";
         return Promise.resolve(undefined);
     }
@@ -217,7 +217,7 @@ export const InitialiseByRequest = async (
     let reqObj = await GetRequestObject(item);
     if (!reqObj) {
         item.status.cacheStatus = "prepared";
-        if (item.fullUrl) {
+        if (item.fullUrl && item.fullUrl !== "/") {
             reqObj = BuildRequestObject(item);
             CleanRequestObject(item, reqObj);
         } else {
@@ -269,7 +269,7 @@ export const UpdateCachedItem = async (
     let reqObj = await GetRequestObject(item);
     if (!reqObj) {
         item.status.cacheStatus = "prepared";
-        if (item.fullUrl) {
+        if (item.fullUrl && item.fullUrl !== "/") {
             reqObj = BuildRequestObject(item);
             CleanRequestObject(item, reqObj);
         } else {

--- a/src/ts/Implementations/CacheItem.ts
+++ b/src/ts/Implementations/CacheItem.ts
@@ -102,7 +102,9 @@ const GetRequestObject = async (
     const itemCacheState: Record<string, boolean> = {
         cacheExists: !!itemCache,
         reqObjectLoaded:
-            item.requestObject && item.requestObject.url === item.fullUrl,
+            item.isValid &&
+            item.requestObject &&
+            item.requestObject.url === item.fullUrl,
     };
 
     if (!itemCacheState.cacheExists) {

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -31,7 +31,8 @@ export const ManifestAPIURL = "/manifest/v1";
 export class Manifest extends PublishableItem<TManifestData> {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     constructor(opts?: any) {
-        super(opts, "", ROUTES_FOR_REGISTRATION.manifest);
+        super(opts, ManifestAPIURL, ROUTES_FOR_REGISTRATION.manifest);
+        this.requestObject = new Request(ManifestAPIURL);
     }
 
     get pages(): Record<string, TWagtailPage> {
@@ -214,7 +215,9 @@ export class Manifest extends PublishableItem<TManifestData> {
             }
         );
         if (pageId === undefined) {
-            throw new ManifestError("location not found in manifest");
+            throw new ManifestError(
+                `Location ${locationHash} not found in manifest`
+            );
         }
         return this.getSpecificPage(pageId);
     }

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -32,7 +32,7 @@ export class Manifest extends PublishableItem<TManifestData> {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     constructor(opts?: any) {
         super(opts, ManifestAPIURL, ROUTES_FOR_REGISTRATION.manifest);
-        this.requestObject = new Request(ManifestAPIURL);
+        this.requestObject = new Request(ROUTES_FOR_REGISTRATION.manifest);
     }
 
     get pages(): Record<string, TWagtailPage> {
@@ -102,6 +102,10 @@ export class Manifest extends PublishableItem<TManifestData> {
         }
 
         if (!this.isInitialised) {
+            return false;
+        }
+
+        if (this.version === -1) {
             return false;
         }
 


### PR DESCRIPTION
# Description

In certain circumstances the manifest cache would end up with an additional item in it with a name of `/`.

Also reloading (especially hot-reloading) of any page excluding the home page would result in strange behaviours.

The `/` item was nominally caused by the `Manifest` constructor not finishing it's job to correctly redefine its `requestObject` with the correct URL.  But we also didn't explicitly check for a `fullUrl` of `/` as a test for an undefined `fullUrl` so those tests were added as well.

Furthermore we weren't correctly checking whether the `Manifest` that we did have was properly valid. The `Manifest`'s `isValid` test needed a tweak to check whether it was just 'new', or whether it had actually been initialised from somewhere.  And then `GetRequestObject` needed to have a reference to `isValid` added to its internal state tracking for whether the requested object had actually been loaded or not. 