### PR TITLE
542 video loading bug

### DIFF
--- a/src/riot/Lesson/AudioCard.riot.html
+++ b/src/riot/Lesson/AudioCard.riot.html
@@ -36,7 +36,7 @@
                 browserSupport: () => gettext("Your browser does not support the audio element."),
                 cached: () => gettext("This audio will play offline."),
                 notCached: () => gettext("This audio is not available offline."),
-                missing: () => gettext("Sorry: This video is missing.")
+                missing: () => gettext("Sorry: This audio is missing.")
             },
 
             onBeforeMount(props, state) {

--- a/src/riot/Lesson/AudioCard.riot.html
+++ b/src/riot/Lesson/AudioCard.riot.html
@@ -3,12 +3,16 @@
         <h3 class="media-title">{props.media.title}</h3>
         <p class="media-description">{props.media.description}</p>
         <audio 
+            if="{ !state.src }"
             controls
             crossorigin="anonymous"
             onplay="{ (event) => storeAnalytics(event) }"
             >
             <span>{ TRANSLATIONS.browserSupport() }</span>
         </audio>
+        <p class="error-message" if="{ !state.src }">
+            { TRANSLATIONS.missing() }
+        </p>
         <p if={state.cached}>{ TRANSLATIONS.cached() }</p>
         <p if={!state.cached}>{ TRANSLATIONS.notCached() }</p>
     </div>
@@ -32,6 +36,7 @@
                 browserSupport: () => gettext("Your browser does not support the audio element."),
                 cached: () => gettext("This audio will play offline."),
                 notCached: () => gettext("This audio is not available offline."),
+                missing: () => gettext("Sorry: This video is missing.")
             },
 
             onBeforeMount(props, state) {
@@ -39,14 +44,20 @@
                 const asset = this.page.PETEgetMediaRenditions(
                     props.media.id
                 );
-                // Choose smallest media item. Much more elaborate strategies are possible, but they need coordination with the backend 
-                // (through TranscodeDefinition objects) to establish a convention on label use. For instance, for audio, the bitrate
-                // (32/64/128kbit ?) could be encoded into the label, and so could the codec (opus/ogg ?).
-                const src = getMediaUrl(Object.values(asset.renditions).sort((el1,el2) => el1.size - el2.size)[0].mediapath);
+                const renditions = Object.values(!!asset ? asset.renditions || {} : {});
+                let src = "";
+                if (renditions.length) {
+                    // Choose smallest media item. Much more elaborate strategies are possible, but they need coordination with the backend 
+                    // (through TranscodeDefinition objects) to establish a convention on label use. For instance, for audio, the bitrate
+                    // (32/64/128kbit ?) could be encoded into the label, and so could the codec (opus/ogg ?).
+                    src = getMediaUrl(renditions.sort((el1,el2) => el1.size - el2.size)[0].mediapath);
+                }
                 this.state.src = src;
-                isItemCached(src).then(cached => {
-                    this.update({cached});
-                });
+                if (src) {
+                    isItemCached(src).then(cached => {
+                        this.update({cached});
+                    });
+                }
             },
 
             storeAnalytics() {

--- a/src/riot/Lesson/VideoCard.riot.html
+++ b/src/riot/Lesson/VideoCard.riot.html
@@ -1,6 +1,7 @@
 <VideoCard>
     <div>
         <video
+            if="{ !state.src }"
             src="{ state.src }"
             width="100%"
             crossorigin="anonymous"
@@ -11,6 +12,9 @@
             <!-- if preload set to none the video will not actually be requested, if set to auto it is requested -->
             <span>{ TRANSLATIONS.browserSupport() }</span>
         </video>
+        <p class="error-message" if="{ !state.src }">
+            { TRANSLATIONS.missing() }
+        </p>        
         <h3 class="media-title">{props.media.title}</h3>
         <p class="media-description">{props.media.description}</p>
         <p if={state.cached}>{ TRANSLATIONS.cached() }</p>
@@ -33,9 +37,10 @@
             },
 
             TRANSLATIONS: {
-                browserSupport: () => gettext('Your browser does not support the video element.'),
-                cached: () => gettext('This video will play offline.'),
-                notCached: () => gettext('This video is not available offline.'),
+                browserSupport: () => gettext("Your browser does not support the video element."),
+                cached: () => gettext("This video will play offline."),
+                notCached: () => gettext("This video is not available offline."),
+                missing: () => gettext("Sorry: This video is missing.")
             },
 
             onBeforeMount(props, state) {
@@ -43,14 +48,20 @@
                 const asset = this.page.PETEgetMediaRenditions(
                     props.media.id
                 );
-                // Choose smallest media item. Much more elaborate strategies are possible, but they need coordination with the backend 
-                // (through TranscodeDefinition objects) to establish a convention on label use. For instance, for audio, the bitrate
-                // (32/64/128kbit ?) could be encoded into the label, and so could the codec (opus/ogg ?).
-                const src = getMediaUrl(Object.values(asset.renditions).sort((el1,el2) => el1.size - el2.size)[0].mediapath);
+                const renditions = Object.values(!!asset ? asset.renditions || {} : {});
+                let src = "";
+                if (renditions.length) {
+                    // Choose smallest media item. Much more elaborate strategies are possible, but they need coordination with the backend 
+                    // (through TranscodeDefinition objects) to establish a convention on label use. For instance, for audio, the bitrate
+                    // (32/64/128kbit ?) could be encoded into the label, and so could the codec (opus/ogg ?).
+                    src = getMediaUrl(renditions.sort((el1,el2) => el1.size - el2.size)[0].path);
+                }
                 this.state.src = src;
-                isItemCached(src).then(cached => {
-                    this.update({cached});
-                });
+                if (src) {
+                    isItemCached(src).then(cached => {
+                        this.update({cached});
+                    });
+                }
             },
 
             storeAnalytics() {

--- a/src/riot/Lesson/VideoCard.riot.html
+++ b/src/riot/Lesson/VideoCard.riot.html
@@ -14,7 +14,7 @@
         </video>
         <p class="error-message" if="{ !state.src }">
             { TRANSLATIONS.missing() }
-        </p>        
+        </p>
         <h3 class="media-title">{props.media.title}</h3>
         <p class="media-description">{props.media.description}</p>
         <p if={state.cached}>{ TRANSLATIONS.cached() }</p>
@@ -54,7 +54,7 @@
                     // Choose smallest media item. Much more elaborate strategies are possible, but they need coordination with the backend 
                     // (through TranscodeDefinition objects) to establish a convention on label use. For instance, for audio, the bitrate
                     // (32/64/128kbit ?) could be encoded into the label, and so could the codec (opus/ogg ?).
-                    src = getMediaUrl(renditions.sort((el1,el2) => el1.size - el2.size)[0].path);
+                    src = getMediaUrl(renditions.sort((el1,el2) => el1.size - el2.size)[0].mediapath);
                 }
                 this.state.src = src;
                 if (src) {

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -329,9 +329,16 @@ export class Page extends PublishableItem<TWagtailPageData> {
         assetType: string
     ): TAssetEntry | undefined {
         const assets = this.manifestData.assets;
-        return assets.find((a: TAssetEntry) => {
+        const filteredAssets = assets.find((a: TAssetEntry) => {
             return a.id === id.toString() && a.type === assetType;
         });
+        // Handy code if you want to check what assets are being retrieved
+        // console.log(
+        //     `Getting ${assetType} asset:${id}, and found ${JSON.stringify(
+        //         filteredAssets
+        //     )}`
+        // );
+        return filteredAssets;
     }
 
     PETEgetImageRenditions = (id: number | string): TAssetEntry | undefined =>


### PR DESCRIPTION
Closes #542 

# Description

The `VideoCard` riot tag does not allow for when a video file is not present (.e.g it's been deleted, but is still listed in the manifest).
So this adds some more 'graceful' error handling, following the pattern of `ImageWrapper`.

`AudioCard` has the same problem so an equivalent fix has been made for it.

A test case can be found by following the links in the original issue