### PR TITLE
Point TeachingActivity at the correct field

### DIFF
--- a/src/ts/Implementations/Specific/TeachingActivity.ts
+++ b/src/ts/Implementations/Specific/TeachingActivity.ts
@@ -7,22 +7,22 @@ export default class TeachingActivity extends Page {
     }
 
     get description(): string {
-        return this.data.description;
+        return this.storedData?.description || "";
     }
 
     get plan(): any {
-        return this.data.plan;
+        return this.storedData?.plan || {};
     }
 
     get teach(): any {
-        return this.data.teach;
+        return this.storedData?.teach || {};
     }
 
     get extend(): any {
-        return this.data.extend;
+        return this.storedData?.extend || {};
     }
 
     get curriculum(): string {
-        return this.data.curriculum_id;
+        return this.storedData?.curriculum_id || "";
     }
 }


### PR DESCRIPTION
# Description

TeachingActivity's members were pointing at `data` when they needed to be pointing at `storedData`

The code is written in that way (optional chaining `?.` plus an `||` default) to stop eslint complaining.