### PR TITLE
Restore JWT for Page and Manifest

### DIFF
--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -12,6 +12,9 @@ import {
 } from "../Constants";
 import { getBrowser } from "../PlatformDetection";
 
+// See ts/Typings for the type definitions for these imports
+import { BACKEND_BASE_URL } from "js/urls";
+
 /** A asset ( binary resource ) than can be cached
  */
 export class Asset extends PublishableItem {
@@ -62,10 +65,18 @@ export class Asset extends PublishableItem {
     /**
      * The options to make an asset request
      */
-    get requestOptions(): any {
+    get requestOptions(): RequestInit {
+        const headers: any = {
+            "Content-Type": this.contentType,
+        };
+
         return {
             cache: "force-cache", // assets are (almost always) invariant on filename
-        };
+            headers: headers,
+            method: "GET",
+            mode: "cors",
+            referrer: BACKEND_BASE_URL,
+        } as RequestInit;
     }
 
     /**
@@ -92,6 +103,23 @@ export class Asset extends PublishableItem {
      */
     get type(): string | undefined {
         return this.entry?.type;
+    }
+
+    /** The mime type of this asset */
+    get contentType(): string {
+        const browser = getBrowser().name;
+        switch (this.type) {
+            case "image":
+                return browser === "Safari" ? "image/jpeg" : "image/webp";
+            case "video":
+                // Safari does support webm to a limited degree
+                return browser === "Safari" ? "video/mp4" : "video/webm";
+            case "audio":
+                return browser === "Safari" ? "audio/ogg" : "audio/mp4";
+            default:
+                // Default is for JSON, and we don't care about the browser
+                return "application/json";
+        }
     }
 
     /**

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -66,13 +66,8 @@ export class Asset extends PublishableItem {
      * The options to make an asset request
      */
     get requestOptions(): RequestInit {
-        const headers: any = {
-            "Content-Type": this.contentType,
-        };
-
         return {
             cache: "force-cache", // assets are (almost always) invariant on filename
-            headers: headers,
             method: "GET",
             mode: "cors",
             referrer: BACKEND_BASE_URL,
@@ -103,23 +98,6 @@ export class Asset extends PublishableItem {
      */
     get type(): string | undefined {
         return this.entry?.type;
-    }
-
-    /** The mime type of this asset */
-    get contentType(): string {
-        const browser = getBrowser().name;
-        switch (this.type) {
-            case "image":
-                return browser === "Safari" ? "image/jpeg" : "image/webp";
-            case "video":
-                // Safari does support webm to a limited degree
-                return browser === "Safari" ? "video/mp4" : "video/webm";
-            case "audio":
-                return browser === "Safari" ? "audio/ogg" : "audio/mp4";
-            default:
-                // Default is for JSON, and we don't care about the browser
-                return "application/json";
-        }
     }
 
     /**

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -17,8 +17,9 @@ import TeachingTopic from "./Specific/TeachingTopic";
 import TeachingActivity from "./Specific/TeachingActivity";
 
 // See ts/Typings for the type definitions for these imports
-import { ROUTES_FOR_REGISTRATION } from "js/urls";
+import { BACKEND_BASE_URL, ROUTES_FOR_REGISTRATION } from "js/urls";
 import { storeManifest, getManifestFromStore } from "ReduxImpl/Interface";
+import { getAuthenticationToken } from "js/AuthenticationUtilities";
 
 const logger = new Logger("Manifest");
 
@@ -30,6 +31,7 @@ class ManifestError extends Error {
 }
 
 export const ManifestAPIURL = `${process.env.API_BASE_URL}/manifest/v1`;
+export const ManifestCacheKey = "canoe-manifest";
 
 export class Manifest extends PublishableItem implements StorableItem {
     /**
@@ -42,16 +44,28 @@ export class Manifest extends PublishableItem implements StorableItem {
      * The cache in which the manifest is stored
      */
     get cacheKey(): string {
-        return "canoe-manifest";
+        return ManifestCacheKey;
     }
 
     /**
      * The options to make a manifest request
      */
-    get requestOptions(): any {
+    get requestOptions(): RequestInit {
+        const headers: any = {
+            "Content-Type": "application/json",
+        };
+        const token = getAuthenticationToken();
+        if (token) {
+            headers["Authorization"] = `JWT ${token}`;
+        }
+
         return {
             cache: "default", // manifest can be returned from cache ( has conditional handling )
-        };
+            headers: headers,
+            method: "GET",
+            mode: "cors",
+            referrer: BACKEND_BASE_URL,
+        } as RequestInit;
     }
 
     /** StorableItem implementations */

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -59,9 +59,9 @@ export class Manifest extends PublishableItem implements StorableItem {
         };
         const token = getAuthenticationToken();
         if (token) {
-            reqInit["headers"] = {Authorization: `JWT ${token}`};
+            reqInit["headers"] = { Authorization: `JWT ${token}` };
         }
-       
+
         return reqInit as RequestInit;
     }
 

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -51,21 +51,18 @@ export class Manifest extends PublishableItem implements StorableItem {
      * The options to make a manifest request
      */
     get requestOptions(): RequestInit {
-        const headers: any = {
-            "Content-Type": "application/json",
-        };
-        const token = getAuthenticationToken();
-        if (token) {
-            headers["Authorization"] = `JWT ${token}`;
-        }
-
-        return {
+        const reqInit: any = {
             cache: "default", // manifest can be returned from cache ( has conditional handling )
-            headers: headers,
             method: "GET",
             mode: "cors",
             referrer: BACKEND_BASE_URL,
-        } as RequestInit;
+        };
+        const token = getAuthenticationToken();
+        if (token) {
+            reqInit["headers"] = {Authorization: `JWT ${token}`};
+        }
+       
+        return reqInit as RequestInit;
     }
 
     /** StorableItem implementations */

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -61,21 +61,18 @@ export class Page extends PublishableItem implements StorableItem {
      * The options to make an page api request
      */
     get requestOptions(): RequestInit {
-        const headers: any = {
-            "Content-Type": "application/json",
-        };
-        const token = getAuthenticationToken();
-        if (token) {
-            headers["Authorization"] = `JWT ${token}`;
-        }
-
-        return {
+        const reqInit: any = {
             cache: "force-cache", // pages have version query params we can rely on the cache
-            headers: headers,
             method: "GET",
             mode: "cors",
             referrer: BACKEND_BASE_URL,
-        } as RequestInit;
+        };
+        const token = getAuthenticationToken();
+        if (token) {
+            reqInit["headers"] = {Authorization: `JWT ${token}`};
+        }
+       
+        return reqInit as RequestInit;
     }
 
     // StorableItem implementations

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -6,12 +6,15 @@ import { StorableItem } from "../Interfaces/StorableItem";
 import { PublishableItem } from "../Implementations/PublishableItem";
 import { Asset } from "../Implementations/Asset";
 
+import Logger from "../Logger";
+
 // See ts/Typings for the type definitions for these imports
+import { getAuthenticationToken } from "js/AuthenticationUtilities";
+import { BACKEND_BASE_URL } from "js/urls";
 import {
     getPageData as getPageDataFromStore,
     storePageData,
 } from "ReduxImpl/Interface";
-import Logger from "../Logger";
 
 const logger = new Logger("Page");
 
@@ -57,10 +60,22 @@ export class Page extends PublishableItem implements StorableItem {
     /**
      * The options to make an page api request
      */
-    get requestOptions(): any {
+    get requestOptions(): RequestInit {
+        const headers: any = {
+            "Content-Type": "application/json",
+        };
+        const token = getAuthenticationToken();
+        if (token) {
+            headers["Authorization"] = `JWT ${token}`;
+        }
+
         return {
             cache: "force-cache", // pages have version query params we can rely on the cache
-        };
+            headers: headers,
+            method: "GET",
+            mode: "cors",
+            referrer: BACKEND_BASE_URL,
+        } as RequestInit;
     }
 
     // StorableItem implementations
@@ -210,6 +225,10 @@ export class Page extends PublishableItem implements StorableItem {
         return this.#id;
     }
 
+    get str(): string {
+        return `Page ${this.title}`;
+    }
+
     /**
      * Check if the page is in the correct cache
      * @returns true if this page, assets, and children is cached in the correct cache , false if not
@@ -309,8 +328,4 @@ export class Page extends PublishableItem implements StorableItem {
 
     getAudioRenditions = (id: number | string): TAssetEntry | undefined =>
         this.getAssetsByIdAndType(id, "audio");
-
-    get str(): string {
-        return `Page ${this.title}`;
-    }
 }

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -69,9 +69,9 @@ export class Page extends PublishableItem implements StorableItem {
         };
         const token = getAuthenticationToken();
         if (token) {
-            reqInit["headers"] = {Authorization: `JWT ${token}`};
+            reqInit["headers"] = { Authorization: `JWT ${token}` };
         }
-       
+
         return reqInit as RequestInit;
     }
 


### PR DESCRIPTION
# Description

This restores the use of a JWT bearer token for `Page` and `Manifest`.

It also restores the type for these requestOptions to `RequestInit` and fixes a bug in `PublishableItem.ts` `getResponseFromCache` where the wrong data was being passed for the `caches.match` query options