### PR TITLE
'Original' rendition for audio video

### DIFF
--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -29,7 +29,7 @@
                 const assetEntry = this.page.getImageRenditions(image.id);
                 if (assetEntry) {
                     try {
-                        this.state.imagePath = Asset.Url(assetEntry);
+                        this.state.imagePath = Asset.url(assetEntry);
                     } catch (error) {
                         if (error instanceof MissingImageError) {
                             this.state.imagePath = "";

--- a/src/riot/Lesson/AudioCard.riot.html
+++ b/src/riot/Lesson/AudioCard.riot.html
@@ -44,7 +44,7 @@
                 );
                 let src = "";
                 try {
-                    src = Asset.Url(assetEntry);
+                    src = Asset.url(assetEntry);
                 } catch {
                     // No compatible rendition found, therefore no url
                     src = "";

--- a/src/riot/Lesson/VideoCard.riot.html
+++ b/src/riot/Lesson/VideoCard.riot.html
@@ -47,7 +47,7 @@
                 );
                 let src = "";
                 try {
-                    src = Asset.Url(assetEntry);
+                    src = Asset.url(assetEntry);
                 } catch {
                     // No compatible rendition found, therefore no url
                     src = "";


### PR DESCRIPTION
# Description

The 'audio' and 'video' 'original' renditions have a different name, they are `original-audio` and `original-video` respectively.

So we need special code just for them ... when did you last see a `while` loop?

Also, the ugly differential casing the @md8n introduced has been wound back, because we we're looking directly at that method anyway.
