### PR TITLE
Image cards next to each other now update

### DIFF
--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -38,6 +38,12 @@
                 }
             },
 
+            onBeforeUpdate(props, state) {
+                if (props.image) {
+                    this.loadImage(props.image);
+                }
+            },
+
             onBeforeMount(props, state) {
                 this.page = getRoute().page;
                 if (props.image) {


### PR DESCRIPTION
bug report from Juliana
"for example this one https://canoe-csp.catalpa.build/#/site/learn/welcome/navigating-the-essential-emergency-care-systems-training-program:content:6
2:01 PM
i continue to see the image from the previous card
2:01 PM
and on the next 4 cards the same image
2:02 PM
if i navigate back, it gets the image of the first back card, and then all other cards will show that image
"


