### PR TITLE
Wrangling renditions preferred vs. smallest

### DIFF
--- a/src/ts/Constants.ts
+++ b/src/ts/Constants.ts
@@ -5,11 +5,25 @@ export const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";
 // Rendition Identifiers
 // - see canoe-backend repo - TranscodeDefinition.json
 // Image Renditions
-export const WEBP_RENDITION = "width-800|format-webp";
-export const JPEG_RENDITION = "width-600|format-jpeg";
+export const WEBP_RENDITION = "width-800|format-webp"; // .webp
+export const JPEG_RENDITION = "width-600|format-jpeg"; // .jpeg
 // Video Renditions
-export const WEBM_RENDITION = "webm-mono-360p-25fps-256kbit";
-export const MP4V_RENDITION = "video-streamcopy-mp4mux";
+export const ORIG_V_RENDITION = "original-video"; // Any extension
+export const H264_360P_RENDITION = "H264-360p-28"; // .mp4
+export const H264_480P_RENDITION = "H264-480p-28"; // .mp4
+export const H265_360P_RENDITION = "H265-360p-28q"; // .mp4
+export const H265_480P_RENDITION = "H265-480p-20q"; // .mp4
+export const VP9_360P_RENDITION = "VP9-360p-35q"; // .webm
+export const VP9_480P_RENDITION = "VP9-480p-20q"; // .webm
+export const WEBM_RENDITION = "webm-mono-360p-25fps-256kbit"; // .webm
 // Audio Renditions
-export const OPUS_RENDITION = "opus-mono-32kbit"; // AKA ogg
-export const MP4A_RENDITION = "audio-streamcopy-mp4mux";
+export const ORIG_A_RENDITION = "original-audio"; // Any extension
+export const OPUS_RENDITION = "opus-mono-32kbit"; // .ogg
+// Other Renditions
+export const ORIG_RENDITION = "original"; // Any extension
+
+// Inactive (Previous/Unused Transcodes)
+export const AV1_360P_RENDITION = "AV1-360p-48q";
+export const AV1_480P_RENDITION = "AV1-480p-32q";
+export const MP4MUXV_RENDITION = "video-streamcopy-mp4mux";
+export const MP4MUXA_RENDITION = "audio-streamcopy-mp4mux";

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -4,16 +4,48 @@ import { PublishableItem } from "./PublishableItem";
 
 import {
     JPEG_RENDITION,
-    MP4A_RENDITION,
-    MP4V_RENDITION,
-    OPUS_RENDITION,
-    WEBM_RENDITION,
     WEBP_RENDITION,
+    ORIG_V_RENDITION,
+    H264_360P_RENDITION,
+    H264_480P_RENDITION,
+    H265_360P_RENDITION,
+    H265_480P_RENDITION,
+    VP9_360P_RENDITION,
+    VP9_480P_RENDITION,
+    WEBM_RENDITION,
+    ORIG_A_RENDITION,
+    OPUS_RENDITION,
+    ORIG_RENDITION,
 } from "../Constants";
 import { getBrowser } from "../PlatformDetection";
 
 // See ts/Typings for the type definitions for these imports
 import { BACKEND_BASE_URL } from "js/urls";
+
+/** This is a subjective in-order list of the above rendition IDs
+ * Its intended use is to be intersected with an array of available renditions
+ * for a given asset, to then get that asset's list of available renditions in
+ * order according to subjective quality / size
+ */
+const RENDITION_PREFERENCE = [
+    VP9_480P_RENDITION,
+    VP9_360P_RENDITION,
+    H264_480P_RENDITION,
+    H264_360P_RENDITION,
+    H265_480P_RENDITION,
+    H265_360P_RENDITION,
+    WEBM_RENDITION,
+    ORIG_V_RENDITION,
+    OPUS_RENDITION,
+    ORIG_A_RENDITION,
+    WEBP_RENDITION,
+    JPEG_RENDITION,
+    ORIG_RENDITION,
+];
+
+/** A subjective size difference value,
+ * whereby we will take the preferred rendition over the smallest rendition */
+const SIZE_DIFF_PERCENT = 0.02;
 
 /** A asset ( binary resource ) than can be cached
  */
@@ -131,47 +163,108 @@ export class Asset extends PublishableItem {
 
     static platformSpecificRendition(asset: TAssetEntry): TRendition {
         const browser = getBrowser().name;
-        let renditionSpec: string;
+        let rendDefs: string[];
+        let rendCount = 0;
         switch (asset.type) {
             case "image":
-                renditionSpec =
-                    browser === "Safari" ? JPEG_RENDITION : WEBP_RENDITION;
+                rendDefs =
+                    browser === "Safari" ? [JPEG_RENDITION] : [WEBP_RENDITION];
                 break;
             case "video":
-                renditionSpec =
-                    browser === "Safari" ? MP4V_RENDITION : WEBM_RENDITION;
+                rendDefs = [
+                    ORIG_V_RENDITION,
+                    H264_360P_RENDITION,
+                    H264_480P_RENDITION,
+                ];
+                rendCount = rendDefs.length;
+                switch (browser) {
+                    case "Chrome": // and 'Edge'
+                        rendDefs.splice(
+                            rendCount,
+                            0,
+                            VP9_360P_RENDITION,
+                            VP9_480P_RENDITION,
+                            WEBM_RENDITION
+                        );
+                        break;
+                    case "Firefox":
+                        rendDefs.splice(rendCount, 0, WEBM_RENDITION);
+                        break;
+                    case "Safari":
+                        rendDefs.splice(
+                            rendCount,
+                            0,
+                            H265_360P_RENDITION,
+                            H265_480P_RENDITION
+                        );
+                        break;
+                }
                 break;
             case "audio":
-                renditionSpec =
-                    browser === "Safari" ? OPUS_RENDITION : MP4A_RENDITION;
+                rendDefs = [ORIG_A_RENDITION];
+                if (browser !== "Safari") {
+                    rendDefs.splice(rendCount, 0, OPUS_RENDITION);
+                }
                 break;
             case "pdf":
                 // We currently do not need this case (although it is technically accurate)
                 // however it would be nice to have it available in the near future
-                renditionSpec = "original";
+                rendDefs = [ORIG_RENDITION];
                 break;
             default:
-                renditionSpec = "original";
+                rendDefs = [ORIG_RENDITION];
+                break;
         }
-        while (!(renditionSpec in asset.renditions)) {
-            if (!renditionSpec.startsWith("original")) {
-                // Force it back to original if we don't have that rendition
-                renditionSpec = "original";
-                continue;
-            } else if (
-                renditionSpec === "original" &&
-                ["audio", "video"].includes(asset.type)
-            ) {
-                // Force it to original + asset.type
-                renditionSpec = `original-${asset.type}`;
-                continue;
-            }
+
+        const renditionSpecs = rendDefs.filter(
+            (def) => def in asset.renditions
+        );
+        if (renditionSpecs.length === 0) {
             // Not found - throw
             throw new Error(
                 "Renditions (optimised or original) cannot be accessed"
             );
         }
+        if (renditionSpecs.length === 1) {
+            // Only one rendition available, so no need for any further work, just return it
+            return asset.renditions[renditionSpecs[0]];
+        }
 
-        return asset.renditions[renditionSpec];
+        // Get the available renditions in a 'preferred' order
+        const prefRenditionSpecs = RENDITION_PREFERENCE.filter((pref) =>
+            renditionSpecs.includes(pref)
+        );
+
+        const hasSize = prefRenditionSpecs.every((pref) =>
+            Object.prototype.hasOwnProperty.call(asset.renditions[pref], "size")
+        );
+        if (!hasSize) {
+            // We can't compare size, so just return the first 'preferred' rendition
+            return asset.renditions[prefRenditionSpecs[0]];
+        }
+
+        // Get the available renditions in order of size (smallest to largest)
+        const sizedRenditionSpecs = renditionSpecs.sort(
+            (a, b) =>
+                (asset.renditions[a].size as number) -
+                (asset.renditions[b].size as number)
+        );
+
+        // Compare 'preferred' to size
+        if (prefRenditionSpecs[0] === sizedRenditionSpecs[0]) {
+            // They agree
+            return asset.renditions[prefRenditionSpecs[0]];
+        }
+        // Size difference as a percent
+        const sizeDiff =
+            (asset.renditions[sizedRenditionSpecs[0]].size as number) /
+            (asset.renditions[prefRenditionSpecs[0]].size as number);
+        if (1 - sizeDiff < SIZE_DIFF_PERCENT) {
+            // Within 2% (subjective), close enough
+            return asset.renditions[prefRenditionSpecs[0]];
+        }
+
+        // Return the smallest then
+        return asset.renditions[prefRenditionSpecs[0]];
     }
 }


### PR DESCRIPTION
# Description

This handles the new rendition values that can show up.  It also does a limited amount of processing to determine 'preferred' and 'smallest' rendition when there is more than one available to determine an actual 'preferred' rendition to download.