### PR TITLE
temporary fix for savedAnswer bug

### DIFF
--- a/src/riot/Lesson/TestSingleAnswer.riot.html
+++ b/src/riot/Lesson/TestSingleAnswer.riot.html
@@ -47,10 +47,10 @@
                 if (!savedAnswer) {
                     return;
                 }
-
-                this.update({
-                    selectedAnswer: savedAnswer[0],
-                });
+                // this is causing state bugs in JID, where when two questions side by side have the same possible answers (for instance true/false or agree/disagree), when you click through to the second question, your answer from the previous question will be selected (without you selecting anything). This is obviously not ideal behaviour. This restoreSavedAnswer logic doesn't work as expected for paging back through questions anyway, so perhaps it's best to simply comment out this code for now (due to time constraints) and mark it as a big TODO to look at without the added pressure of a deadline.
+                // this.update({
+                //     selectedAnswer: savedAnswer[0],
+                // });
             },
 
             doAnswersMatch(left, right) {

--- a/src/riot/Lesson/TestSingleAnswer.riot.html
+++ b/src/riot/Lesson/TestSingleAnswer.riot.html
@@ -47,7 +47,15 @@
                 if (!savedAnswer) {
                     return;
                 }
-                // this is causing state bugs in JID, where when two questions side by side have the same possible answers (for instance true/false or agree/disagree), when you click through to the second question, your answer from the previous question will be selected (without you selecting anything). This is obviously not ideal behaviour. This restoreSavedAnswer logic doesn't work as expected for paging back through questions anyway, so perhaps it's best to simply comment out this code for now (due to time constraints) and mark it as a big TODO to look at without the added pressure of a deadline.
+                // this is causing state bugs in JID, where when two questions
+                // side by side have the same possible answers (for instance
+                // true/false or agree/disagree), when you click through to the second
+                // question, your answer from the previous question will be selected
+                // (without you selecting anything). This is obviously not ideal
+                // behaviour. This restoreSavedAnswer logic doesn't work as expected for
+                // paging back through questions anyway, so perhaps it's best to simply
+                // comment out this code for now (due to time constraints) and mark it as
+                // a big TODO to look at without the added pressure of a deadline.
                 // this.update({
                 //     selectedAnswer: savedAnswer[0],
                 // });


### PR DESCRIPTION
This is a temporary fix - simply comments out the offending code to prevent answers being selected by the previous question. The `restoreSavedAnswer()` logic doesn't work anyway, (you can't page back through questions and have saved answers show up). I'll keep working on this, but this is a temporary fix PR in case I can't get it working today (: