### PR TITLE
disable `next` button on tests until answer has been selected

### DIFF
--- a/src/riot/Lesson/CourseExam.riot.html
+++ b/src/riot/Lesson/CourseExam.riot.html
@@ -174,12 +174,14 @@
             },
 
             previousExamCard() {
+                this.update({ currentAnswer: {} });
                 location.hash = `${this.course.loc_hash}:exam:${this.state.cardNumber - 1}`;
             },
 
             nextExamCard() {
                 const { cardNumber, cards, card, currentAnswer } = this.state;
                 ExamGrader.saveExamAnswer(card.id, currentAnswer);
+                this.update({ currentAnswer: {} });
                 if( cardNumber === cards.length ) {
                     location.hash = `${this.course.loc_hash}:exam:results`;
                 } else {

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -379,6 +379,7 @@ TestSingleAnswer {
                 font-size: 1.2em;
                 margin: 0;
                 padding: 0.5em 1em;
+                line-height: 1.3em;
             }
 
             &.radio {

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -378,6 +378,7 @@ TestSingleAnswer {
             p {
                 font-size: 1.2em;
                 margin: 0;
+                padding: 0.5em 1em;
             }
 
             &.radio {
@@ -387,6 +388,7 @@ TestSingleAnswer {
                 display: flex;
                 align-items: center;
                 justify-content: center;
+                text-align: center;
             }
 
             &.selected-pending {


### PR DESCRIPTION
resets the `currentAnswer` on pagination so that the `next` button is disabled on question cards unless an answer is selected

also adds padding to the single choice buttons, and centre aligns text
![Screen Shot 2021-03-31 at 4 44 32 pm](https://user-images.githubusercontent.com/12974326/113227641-e35f4a00-92de-11eb-9013-847bad028d98.png)
