### PR TITLE
579 JID multi choice feedback text bug

### DIFF
--- a/src/riot/Lesson/TestPopupModal.riot.html
+++ b/src/riot/Lesson/TestPopupModal.riot.html
@@ -53,22 +53,34 @@
 
             correctTitleMessage(selectedAnswer) {
                 // title for correct answer feedback
-                return selectedAnswer.feedback.title || gettext("Great");
+                if (selectedAnswer.feedback) {
+                    return selectedAnswer.feedback.title || gettext("Great");
+                }
+                return gettext("Great");
             },
 
             correctTextMessage(selectedAnswer) {
                 // text for correct answer feedback
-                return selectedAnswer.feedback.text || gettext("Well done, keep it up!");
+                if (selectedAnswer.feedback) {
+                    return selectedAnswer.feedback.text || gettext("Well done, keep it up!");
+                }
+                return gettext("Well done, keep it up!");
             },
 
             incorrectTitleMessage(selectedAnswer) {
                 // title for incorrect answer feedback
-                return selectedAnswer.feedback.title || gettext("Oops");
+                if (selectedAnswer.feedback) {
+                    return selectedAnswer.feedback.title || gettext("Oops");
+                }
+                return gettext("Oops");
             },
 
             incorrectTextMessage(selectedAnswer) {
                 // text for incorrect answer feedback
-                return selectedAnswer.feedback.text || gettext("Read the question more carefully!");
+                if (selectedAnswer.feedback) {
+                    return selectedAnswer.feedback.text || gettext("Read the question more carefully!");
+                }
+                return gettext("Read the question more carefully!");
             },
         }
     </script>

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -345,6 +345,10 @@ TestSingleAnswer {
         align-self: start;
         flex: 1;
         width: 100%;
+
+        & + h4 {
+            margin: 1.5em 0 0;
+        }
     }
 }
 


### PR DESCRIPTION
closes #579 

There's a bug in JID ([here](https://canoe-csp.catalpa.build/#/site/learn/test/lesson-test:content:2)) which is preventing users progressing past multiple-choice questions. I believe this is due to the format the FE expects from the api not lining up with the API (I'm not certain why this is only happening in JID).

This change adds some extra handling for when the `feedback` attribute is not present in an answer response, which should hopefully resolve the issue.