### PR TITLE
593: card pagination image bugfix

### DIFF
--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -50,6 +50,8 @@
                             this.state.imagePath = "";
                         }
                     }
+                } else {
+                    this.state.imagePath = "";
                 }
             },
 


### PR DESCRIPTION
fallback logic for images where rendition is undefined / null


Should fix the bug described in the ticket, which is here in JID: Link is here: https://canoe-csp.catalpa.build/#/site/learn/introduction-to-emergency-care/the-value-of-emergency-care:content:3 (going from page 3 to page 4)