### PR TITLE
592 lesson card size fixes

### DIFF
--- a/src/riot/Components/LessonFrame.riot.html
+++ b/src/riot/Components/LessonFrame.riot.html
@@ -26,7 +26,7 @@
             <span class="cross gray"></span>
         </a>
     </TopMenu>
-    <div class="frame-background">
+    <div class="frame-background {userAgent()}">
         <div class="{!props.noCardStyle ? 'card-frame' : 'no-card'}">
             <div class="card-content {props.extrastyleclasses}">
                 <slot />
@@ -51,6 +51,33 @@
                     ? this.props.close()
                     : (window.location.hash = `#${this.props.linkTo}`);
             },
+
+            userAgent() {
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name
+                const userAgentString = navigator.userAgent;
+                let browser = '';
+                let operatingSystem = '';
+
+                if (userAgentString.includes('Safari/')
+                    && !userAgentString.includes('Chrome/')
+                    && !userAgentString.includes('Chromium/')) {
+                    browser = 'safari';
+                } else if (userAgentString.includes('Firefox/')
+                    && !userAgentString.includes('Seamonkey/')) {
+                    browser = 'firefox';
+                } else if (userAgentString.includes('Chrome/')
+                    && !userAgentString.includes('Chromium/')) {
+                    browser = 'chrome';
+                }
+
+                if (userAgentString.includes('iPhone')) {
+                    operatingSystem = 'ios';
+                } else if (userAgentString.includes('Android')) {
+                    operatingSystem = 'android';
+                }
+
+                return `${browser} ${operatingSystem}`;
+            }
         };
     </script>
 </LessonFrame>

--- a/src/riot/Components/LessonFrame.riot.html
+++ b/src/riot/Components/LessonFrame.riot.html
@@ -40,6 +40,7 @@
 
     <script>
         import TopMenu from "RiotTags/Components/TopMenu.riot.html";
+        import { getPlatform } from "ts/PlatformDetection";
 
         export default {
             components: {
@@ -53,30 +54,8 @@
             },
 
             userAgent() {
-                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name
-                const userAgentString = navigator.userAgent;
-                let browser = '';
-                let operatingSystem = '';
-
-                if (userAgentString.includes('Safari/')
-                    && !userAgentString.includes('Chrome/')
-                    && !userAgentString.includes('Chromium/')) {
-                    browser = 'safari';
-                } else if (userAgentString.includes('Firefox/')
-                    && !userAgentString.includes('Seamonkey/')) {
-                    browser = 'firefox';
-                } else if (userAgentString.includes('Chrome/')
-                    && !userAgentString.includes('Chromium/')) {
-                    browser = 'chrome';
-                }
-
-                if (userAgentString.includes('iPhone')) {
-                    operatingSystem = 'ios';
-                } else if (userAgentString.includes('Android')) {
-                    operatingSystem = 'android';
-                }
-
-                return `${browser} ${operatingSystem}`;
+                const { browser } = getPlatform();
+                return browser.name.toLowerCase();
             }
         };
     </script>

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -57,13 +57,24 @@ LessonFrame {
         }
     }
 
+    $base-card-height: calc(100vh - #{$top-menu-height} - 25px - 50px);
+
     .frame-background {
         // the 25px adds some room for the stacked cards below, the 50px is
         // for the buttons
-        height: calc(100vh - #{$top-menu-height} - 25px - 50px);
+        height: $base-card-height;
         display: flex;
         flex-flow: row nowrap;
         align-items: stretch;
+
+        &.safari.ios {
+            height: calc(#{$base-card-height} - 100px);
+        }
+
+        &.chrome.android,
+        &.firefox.android {
+            height: calc(#{$base-card-height} - 60px);
+        }
     }
 
     .card-frame {

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -67,12 +67,12 @@ LessonFrame {
         flex-flow: row nowrap;
         align-items: stretch;
 
-        &.safari.ios {
+        &.safari {
             height: calc(#{$base-card-height} - 100px);
         }
 
-        &.chrome.android,
-        &.firefox.android {
+        &.chrome,
+        &.firefox {
             height: calc(#{$base-card-height} - 60px);
         }
     }

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -57,11 +57,11 @@ LessonFrame {
         }
     }
 
+    // the 25px adds some room for the stacked cards below, the 50px is
+    // for the buttons
     $base-card-height: calc(100vh - #{$top-menu-height} - 25px - 50px);
 
     .frame-background {
-        // the 25px adds some room for the stacked cards below, the 50px is
-        // for the buttons
         height: $base-card-height;
         display: flex;
         flex-flow: row nowrap;


### PR DESCRIPTION
Mobile browsers have menus that can appear/disappear only on scroll. They take up a lot of space and sometimes don't pay attention to `100vh` calculations, causing things to appear 'below the fold' (this is especially frustrating when your navigation is at the bottom of the screen).

This PR adds changes to detect the OS/browser of a device, and adjust the height of the lesson cards slightly so that the bottom navigation in lessons doesn't disappear below the bottom menu.

I've tested these changes on lots of devices/browsers across browserstack & it seems to do the job!

Safari on iOS before:
<img src="https://user-images.githubusercontent.com/12974326/115170187-61a35500-a103-11eb-8380-6f33e2f0364b.png" width="250">

Safari on iOS after:
<img src="https://user-images.githubusercontent.com/12974326/115170195-67009f80-a103-11eb-8fd6-663b7a94c256.png" width="250">


Chrome on Android before:
<img src="https://user-images.githubusercontent.com/12974326/115170191-6536dc00-a103-11eb-845c-73c240992c4d.png" width="250">

Chrome on Android after:
<img src="https://user-images.githubusercontent.com/12974326/115170193-66680900-a103-11eb-92af-c4aa039331ef.png" width="250">