### PR TITLE
Make bottom menu overridable

### DIFF
--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -47,7 +47,7 @@
             getRoute
         } from "ReduxImpl/Interface";
 
-        import BottomMenu from "RiotTags/Components/BottomMenu.riot.html";
+        import BottomMenu from "riot/Components/BottomMenu.riot.html";
         import PushSubscription from "RiotTags/Components/PushSubscription.riot.html";
         import Toast from "RiotTags/Components/Toast.riot.html";
         import LoadingDots from "RiotTags/Components/LoadingDots.riot.html";


### PR DESCRIPTION
Switching from an alias to a relative path will enable Hamahon to override the Bottom Menu, which is necessary for https://github.com/catalpainternational/hamahon/pull/204