### PR TITLE
PDF document are not accessed through media path

### DIFF
--- a/src/riot/Lesson/PdfCard.riot.html
+++ b/src/riot/Lesson/PdfCard.riot.html
@@ -4,7 +4,7 @@
         >{ TRANSLATIONS.download() }</a
     >
     <script>
-        import { BACKEND_BASE_URL, MEDIA_PATH } from "js/urls";
+        import { BACKEND_BASE_URL } from "js/urls";
 
         export default {
             TRANSLATIONS: {
@@ -12,7 +12,7 @@
             },
 
             getMediaUrl(documentPath) {
-                return `${BACKEND_BASE_URL}${MEDIA_PATH}${documentPath}`;
+                return `${BACKEND_BASE_URL}${documentPath}`;
             },
         };
     </script>


### PR DESCRIPTION
fixes #602 

PDFs are stored as wagtail documents, and accessed through the `/documents` endpoint not the `/media` url
To test upload a document, assign it in a PDF card, check you can view and download it. See the example in the original issue for an existing pdf