### PR TITLE
594 video thumnails

### DIFF
--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -1,93 +1,70 @@
 <ImageWrapper>
-    <div if="{state.imageFullScreen}"
+    <div if="{ asset() && state.imageFullScreen }"
         class="modal-background fade"
-        onclick="{toggleImageFullScreen}">
+        onclick="{ toggleImageFullScreen }">
     </div>
     <img
-        if="{state.imagePath}"
-        alt="{state.image.alt}"
+        if="{ asset() }"
+        src="{ asset().url }"
+        alt="{ asset().title }"
         class="richtext-image {imageClass()}"
         crossorigin="anonymous"
-        src="{state.imagePath}"
     />
-    <div if="{state.imagePath && !state.imageFullScreen}"
+    <div if="{ asset() && !state.imageFullScreen }"
         class="expand-button"
-        onclick="{toggleImageFullScreen}">
+        onclick="{ toggleImageFullScreen }">
         <span class="expand-arrows"></span>
     </div>
-    <div if="{state.imageFullScreen}"
+    <div if="{ state.imageFullScreen }"
         class="contract-button"
-        onclick="{toggleImageFullScreen}">
+        onclick="{ toggleImageFullScreen }">
         <span class="cross gray"></span>
     </div>
-    <p class="error-message" if="{!state.imagePath}">
-        Sorry: image "{state.image.alt}", is missing.
+    <p class="error-message" if="{ !asset() }">
+        { TRANSLATIONS.missing() }
     </p>
 
     <script>
-        import { Asset } from "ts/Implementations/Asset";
         import { getRoute } from "ReduxImpl/Interface";
-        import { MissingImageError } from "js/Errors";
 
-        export default {
-            state: {
-                imagePath: "",
-                image: {
-                    id: "unknown",
-                    alt: "Unknown Image",
+        export default function ImageWraper() {
+            return {
+                TRANSLATIONS: {
+                    missing: () => gettext("Sorry: This image is missing.")
                 },
-                imageFullScreen: false,
-            },
+                state: {
+                    imageFullScreen: false,
+                },
 
-            loadImage(image) {
-                this.state.image = image;
-                const assetEntry = this.page.getImageRenditions(image.id);
-                if (assetEntry) {
-                    try {
-                        this.state.imagePath = Asset.url(assetEntry);
-                    } catch (error) {
-                        if (error instanceof MissingImageError) {
-                            this.state.imagePath = "";
-                        }
-                    }
-                } else {
-                    this.state.imagePath = "";
-                }
-            },
+                get page() {
+                    return getRoute().page;
+                },
 
-            imageClass() {
-                const fullScreen = this.state.imageFullScreen;
-                const devicePortrait = this.state.devicePortrait;
-                const img = this.$("img");
-                const imgHeight = img.naturalHeight;
-                const imgWidth = img.naturalWidth;
+                asset() {
+                    return this.page.imageAsset(this.props.image.id);
+                },
 
-                let imgOrientation;
+                imageClass() {
+                    const fullScreen = this.state.imageFullScreen;
+                    const devicePortrait = this.state.devicePortrait;
+                    const img = this.$("img");
+                    const imgHeight = img.naturalHeight;
+                    const imgWidth = img.naturalWidth;
 
-                if (imgHeight > imgWidth) imgOrientation = 'portrait';
-                if (imgHeight < imgWidth) imgOrientation = 'landscape';
-                if (imgHeight === imgWidth) imgOrientation = 'square';
+                    let imgOrientation;
+
+                    if (imgHeight > imgWidth) imgOrientation = 'portrait';
+                    if (imgHeight < imgWidth) imgOrientation = 'landscape';
+                    if (imgHeight === imgWidth) imgOrientation = 'square';
 
 
-                return fullScreen ? `full-screen ${imgOrientation}` : '';
-            },
+                    return fullScreen ? `full-screen ${imgOrientation}` : '';
+                },
 
-            onBeforeUpdate(props, state) {
-                if (props.image) {
-                    this.loadImage(props.image);
-                }
-            },
-
-            onBeforeMount(props, state) {
-                this.page = getRoute().page;
-                if (props.image) {
-                    this.loadImage(props.image);
-                }
-            },
-
-            toggleImageFullScreen() {
-                this.update({ imageFullScreen: !this.state.imageFullScreen });
-            },
+                toggleImageFullScreen() {
+                    this.update({ imageFullScreen: !this.state.imageFullScreen });
+                },
+            }
         };
     </script>
 </ImageWrapper>

--- a/src/riot/Lesson/AudioCard.riot.html
+++ b/src/riot/Lesson/AudioCard.riot.html
@@ -3,10 +3,11 @@
         <h3 class="media-title">{props.media.title}</h3>
         <p class="media-description">{props.media.description}</p>
         <audio 
-            if="{ state.src }"
-            src="{ state.src }"
-            controls
+            if="{ asset() }"
+            src="{ asset().url }"
+            controls="true"
             crossorigin="anonymous"
+            duration="{ asset().duration }"
             onplay="{ (event) => storeAnalytics(event) }"
             >
             <span>{ TRANSLATIONS.browserSupport() }</span>
@@ -14,54 +15,32 @@
         <p class="error-message" if="{ !state.src }">
             { TRANSLATIONS.missing() }
         </p>
-        <p if={state.cached}>{ TRANSLATIONS.cached() }</p>
-        <p if={!state.cached}>{ TRANSLATIONS.notCached() }</p>
     </div>
 
     <script>
-        import { Asset } from "ts/Implementations/Asset";
         import { getRoute } from "ReduxImpl/Interface";
-        import { isItemCached } from "js/cacheManager/cacheManager";
         import { logClickedPlayOnVideo } from "js/GoogleAnalytics";
 
-        export default {
-            state: {
-                src: "",
-                cached: false
-            },
+        export default function AudioCard() {
+            return {
+                TRANSLATIONS: {
+                    browserSupport: () => gettext("Your browser does not support the audio element."),
+                    missing: () => gettext("Sorry: This audio is missing.")
+                },
 
-            TRANSLATIONS: {
-                browserSupport: () => gettext("Your browser does not support the audio element."),
-                cached: () => gettext("This audio will play offline."),
-                notCached: () => gettext("This audio is not available offline."),
-                missing: () => gettext("Sorry: This audio is missing.")
-            },
+                get page() {
+                    return getRoute().page;
+                },
 
-            onBeforeMount(props, state) {
-                this.page = getRoute().page;
-                const assetEntry = this.page.getAudioRenditions(
-                    props.media.id
-                );
-                let src = "";
-                try {
-                    src = Asset.url(assetEntry);
-                } catch {
-                    // No compatible rendition found, therefore no url
-                    src = "";
-                }
-                this.state.src = src;
-                if (src) {
-                    isItemCached(src).then(cached => {
-                        this.update({cached});
-                    });
-                }
-            },
+                asset() {
+                    return this.page.audioAsset(this.props.media.media_id);
+                },
 
-            storeAnalytics() {
-                const mediaTitle = this.props.media.title;
-                logClickedPlayOnVideo(mediaTitle);
-            },
-
+                storeAnalytics() {
+                    const mediaTitle = this.props.media.title;
+                    logClickedPlayOnVideo(mediaTitle);
+                },
+            }
         };
     </script>
 </AudioCard>

--- a/src/riot/Lesson/VideoCard.riot.html
+++ b/src/riot/Lesson/VideoCard.riot.html
@@ -1,8 +1,10 @@
 <VideoCard>
     <div>
         <video
-            if="{ state.src }"
-            src="{ state.src }"
+            if="{ asset() }"
+            src="{ asset().url }"
+            duration="{ asset().duration }"
+            poster="{ asset().thumbnail }"
             width="100%"
             crossorigin="anonymous"
             controls="true"
@@ -12,58 +14,37 @@
             <!-- if preload set to none the video will not actually be requested, if set to auto it is requested -->
             <span>{ TRANSLATIONS.browserSupport() }</span>
         </video>
-        <p class="error-message" if="{ !state.src }">
+        <p class="error-message" if="{ !asset() }">
             { TRANSLATIONS.missing() }
         </p>
         <h3 class="media-title">{props.media.title}</h3>
         <p class="media-description">{props.media.description}</p>
-
-        <p if="{ state.error === 'no_asset' }">
-            { TRANSLATIONS.noAssetError() }
-        </p>
     </div>
 
     <script>
-        import { Asset } from "ts/Implementations/Asset";
         import { getRoute } from "ReduxImpl/Interface";
-        import { isItemCached } from "js/cacheManager/cacheManager";
         import { logClickedPlayOnVideo } from "js/GoogleAnalytics";
 
-        export default {
-            TRANSLATIONS: {
-                browserSupport: () => gettext('Your browser does not support the video element.'),
-                missing: () => gettext("Sorry: This video is missing.")
-            },
+        export default function VideoCard() {
+            return {
+                TRANSLATIONS: {
+                    browserSupport: () => gettext('Your browser does not support the video element.'),
+                    missing: () => gettext("Sorry: This video is missing.")
+                },
 
-            state: {
-                src: "",
-                cached: false
-            },
+                get page() {
+                    return getRoute().page;
+                },
 
-            onBeforeMount(props, state) {
-                this.page = getRoute().page;
-                const assetEntry = this.page.getVideoRenditions(
-                    props.media.id
-                );
-                let src = "";
-                try {
-                    src = Asset.url(assetEntry);
-                } catch {
-                    // No compatible rendition found, therefore no url
-                    src = "";
-                }
-                this.state.src = src;
-                if (src) {
-                    isItemCached(src).then(cached => {
-                        this.update({cached});
-                    });
-                }
-            },
+                asset() {
+                    return this.page.videoAsset(this.props.media.media_id);
+                },
 
-            storeAnalytics() {
-                const mediaTitle = this.props.media.title;
-                logClickedPlayOnVideo(mediaTitle);
-            },
+                storeAnalytics() {
+                    const mediaTitle = this.props.media.title;
+                    logClickedPlayOnVideo(mediaTitle);
+                },
+            }
         };
     </script>
 </VideoCard>

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -267,4 +267,14 @@ export class Asset extends PublishableItem {
         // Return the smallest then
         return asset.renditions[prefRenditionSpecs[0]];
     }
+
+    get metadata(): Record<string, any> {
+        return this.#page.manifest.storedData?.videometa[this.id];
+    }
+    get thumbnail(): string {
+        return `${process.env.API_BASE_URL}/${this.metadata.thumbnail}`;
+    }
+    get duration(): number {
+        return this.metadata.duration;
+    }
 }

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -348,34 +348,27 @@ export class Page extends PublishableItem implements StorableItem {
         };
     }
 
-    getAssetsByIdAndType(
+    getAssetByIdAndType(
         id: number | string,
         assetType: string
-    ): TAssetEntry | undefined {
-        const assets = this.manifestData.assets;
-        const filteredAssets = assets.find((a: TAssetEntry) => {
+    ): Asset | undefined {
+        const asset = this.manifestAssets.find((a: Asset) => {
             return a.id === id.toString() && a.type === assetType;
         });
-        // Handy code if you want to check what assets are being retrieved
-        // console.log(
-        //     `Getting ${assetType} asset:${id}, and found ${JSON.stringify(
-        //         filteredAssets
-        //     )}`
-        // );
-        return filteredAssets;
+        if (asset === undefined) {
+            logger.warn("Missing asset %s: %s, %s", this.title, id, assetType);
+        }
+        return asset;
     }
 
-    getImageRenditions = (id: number | string): TAssetEntry | undefined =>
-        this.getAssetsByIdAndType(id, "image");
+    imageAsset = (id: number | string): Asset | undefined =>
+        this.getAssetByIdAndType(id, "image");
 
-    getMediaRenditions = (id: number | string): TAssetEntry | undefined =>
-        this.getAssetsByIdAndType(id, "media");
+    videoAsset = (id: number | string): Asset | undefined =>
+        this.getAssetByIdAndType(id, "video");
 
-    getVideoRenditions = (id: number | string): TAssetEntry | undefined =>
-        this.getAssetsByIdAndType(id, "video");
-
-    getAudioRenditions = (id: number | string): TAssetEntry | undefined =>
-        this.getAssetsByIdAndType(id, "audio");
+    audioAsset = (id: number | string): Asset | undefined =>
+        this.getAssetByIdAndType(id, "audio");
 }
 
 type ProgressStatus = "not-started" | "in-progress" | "complete";


### PR DESCRIPTION
Fixes #594
Accompanied by https://github.com/catalpainternational/canoe-backend/pull/159

- Simplifies access to Asset from Page class enabling simpler riot code
- Exposes thumbnail and duration members on Asset
- Simplifies and standardises riot media cards, uses new thumbnail and duration members