### PR TITLE
Make icon colors themeable

### DIFF
--- a/src/riot/Screens/Resources.riot.html
+++ b/src/riot/Screens/Resources.riot.html
@@ -45,7 +45,7 @@
                 <h6 if="{ resource.ready }">{resource.description}</h6>
             </a>
         </div>
-        <p if="{ page.resources.length === 0}">
+        <p if="{ page.resources.length === 0}" class="no-resources">
             { TRANSLATIONS.noArticlesYet() }
         </p>
     </div>

--- a/src/scss/_images.scss
+++ b/src/scss/_images.scss
@@ -41,7 +41,7 @@
 }
 
 .filter-icon {
-    @include mask-icons-shared("~img/levers.svg", contain, $blue);
+    @include mask-icons-shared("~img/levers.svg", contain, $app-accent-color);
     height: 20px;
     width: 20px;
 }
@@ -79,7 +79,7 @@
 
 .settings-icon {
     @extend %bottom-nav-shared;
-    @include mask-icons-shared("~img/cog.svg", contain, $blue);
+    @include mask-icons-shared("~img/cog.svg", contain, $app-accent-color);
 }
 
 .search-icon {
@@ -91,7 +91,7 @@
 }
 
 .checkmark {
-    @include mask-icons-shared("~img/checkmark.svg", contain, $blue);
+    @include mask-icons-shared("~img/checkmark.svg", contain, $app-accent-color);
     height: 16px;
     width: 20px;
 }
@@ -110,17 +110,16 @@
 %stat-icon-shared {
     height: 25px;
     width: 25px;
-    background: $blue;
 }
 
 .checkmark-circle {
     @extend %stat-icon-shared;
-    @include mask-icons-shared("~img/checkmark_circle.svg", contain, $blue);
+    @include mask-icons-shared("~img/checkmark_circle.svg", contain, $app-accent-color);
 }
 
 .road-sign {
     @extend %stat-icon-shared;
-    @include mask-icons-shared("~img/road_sign.svg", contain, $blue);
+    @include mask-icons-shared("~img/road_sign.svg", contain, $app-accent-color);
 }
 
 .plant {
@@ -310,7 +309,7 @@
 }
 
 %status-play {
-    @include status-icon("~img/chevron_right.svg", $blue);
+    @include status-icon("~img/chevron_right.svg", $app-accent-color);
 
     .icon {
         width: 13px;

--- a/src/scss/_images.scss
+++ b/src/scss/_images.scss
@@ -213,13 +213,13 @@
 }
 
 .arrow {
-    @include mask-icons-shared("~img/arrow.svg", contain, $blue);
+    @include mask-icons-shared("~img/arrow.svg", contain, $app-accent-color);
     height: 12px;
     width: 17px;
 }
 
 .download {
-    @include mask-icons-shared("~img/download.svg", contain, $blue);
+    @include mask-icons-shared("~img/download.svg", contain, $app-accent-color);
     height: 22px;
     width: 22px;
     margin-left: -2px;
@@ -234,7 +234,7 @@
 }
 
 .quotation-mark {
-    @include mask-icons-shared("~img/quotation_mark.svg", contain, $blue);
+    @include mask-icons-shared("~img/quotation_mark.svg", contain, $app-accent-color);
     height: 22px;
     width: 18px;
 }

--- a/src/scss/_resources.scss
+++ b/src/scss/_resources.scss
@@ -12,6 +12,10 @@ Resources {
         color: $gray-1;
     }
 
+    .no-resources {
+        margin: 0.5em;
+    }
+
     .list-resources {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
As a part of theming Hamahon, I updated some of the icon colors so that they are themable https://github.com/catalpainternational/hamahon/issues/142

For example these icons:
![image](https://user-images.githubusercontent.com/2395211/116288410-803ac900-a75f-11eb-9cf6-2905e467bff8.png)

