### PR TITLE
Set pdf download link to 'download'

### DIFF
--- a/src/riot/Lesson/PdfCard.riot.html
+++ b/src/riot/Lesson/PdfCard.riot.html
@@ -1,8 +1,6 @@
 <PdfCard>
     <h3>{props.card.title}</h3>
-    <a href="{getMediaUrl(props.card.url)}" target="_blank"
-        >{ TRANSLATIONS.download() }</a
-    >
+    <a href="{getMediaUrl(props.card.url)}" download>{ TRANSLATIONS.download() }</a>
     <script>
         import { BACKEND_BASE_URL } from "js/urls";
 


### PR DESCRIPTION
no new tab, just download, not sure this is what is required on the device.
the old behaviour is open in a new tab and download, the new behaviour is just download.
Possibly worth thinking about opening in a new tab but displaying, or just same tab and displaying