### PR TITLE
Homepage remove of old refs and correct complete check

### DIFF
--- a/src/riot/WagtailPages/AllCoursesList.riot.html
+++ b/src/riot/WagtailPages/AllCoursesList.riot.html
@@ -23,13 +23,12 @@
     <div class="content-wrapper">
         <LoadingDots if="{!page.ready}" extrastyleclasses="dark"></LoadingDots>
         <template
-            if="{page.currentCourse && !page.currentCourse.isFinished()}"
+            if="{page.currentCourse && !page.currentCourse.complete }"
         >
             <h5 class="section-title">{ TRANSLATIONS.continueLearning() }</h5>
             <div class="card-container full-width">
                 <Card
                     contentItem="{ page.currentCourse }"
-                    getCachedPromise="{ course.isAvailableOffline() }"
                 ></Card>
             </div>
         </template>


### PR DESCRIPTION
getCachedPromise is no used anymore
page completion is checked with the `.complete` attribute