### PR TITLE
657 misc tweaks for pep

### DIFF
--- a/src/riot/Components/BasicCard.riot.html
+++ b/src/riot/Components/BasicCard.riot.html
@@ -18,6 +18,14 @@
 
             setInnerHTML() {
                 this.$(".richtext").innerHTML = this.props.card.content;
+                const absolutePath = new RegExp('^(?:[a-z]+:)?//', 'i');
+                const links = [...this.$('.richtext').getElementsByTagName('a')];
+
+                links.forEach((link) => {
+                    if (absolutePath.test(link.href)) {
+                        link.target = "_blank"
+                    }
+                })
             },
 
             onMounted() {

--- a/src/riot/Lesson/ListCard.riot.html
+++ b/src/riot/Lesson/ListCard.riot.html
@@ -1,8 +1,10 @@
 <ListCard>
     <h3 if="{props.card.title}">{ props.card.title }</h3>
-    <p each="{item in props.card.content}">
-        <span if="{props.card.isNumbered}" class="number">{ props.card.content.indexOf(item) + 1 }</span>
-        <span if="{!props.card.isNumbered}" class="bullet">{ "•" }</span>
-        {item}
-    </p>
+    <ol if="{props.card.isNumbered}">
+        <li each="{item in props.card.content}">{item}</li>
+    </ol>
+
+    <ul if="{!props.card.isNumbered}">
+        <li each="{item in props.card.content}">{item}</li>
+    </ul>
 </ListCard>

--- a/src/scss/_activity.scss
+++ b/src/scss/_activity.scss
@@ -74,8 +74,14 @@ ActivityPage {
         padding-bottom: calc(#{$bottom-menu-height});
     }
 
-    img {
+    img.richtext-image {
         width: 100%;
+        border-radius: 8px;
+        margin: unset;
+    }
+
+    ImageWrapper .expand-button {
+        right: 1em;
     }
 
     li {

--- a/src/scss/_activity.scss
+++ b/src/scss/_activity.scss
@@ -84,7 +84,7 @@ ActivityPage {
         right: 1em;
     }
 
-    li {
+    li, p {
         color: $gray-1;
     }
 
@@ -128,6 +128,11 @@ ActivityPage {
         &.last-section .cards-list > * + * {
             border-top: 1px solid $gray-6;
         }
+    }
+
+    TabSection .last-section .cards-list > * + *,
+    ExtendTab .cards-list > * + * {
+        border-top: 1px solid $gray-6;
     }
 
     Html5Card {

--- a/src/scss/_activity.scss
+++ b/src/scss/_activity.scss
@@ -78,6 +78,10 @@ ActivityPage {
         width: 100%;
     }
 
+    li {
+        color: $gray-1;
+    }
+
     PlanTab,
     TeachTab {
         h4 {
@@ -105,26 +109,18 @@ ActivityPage {
             margin: 1.5em 0;
             display: block;
         }
-    }
 
-    ListCard {
-        p {
-            color: $gray-1;
+        .cards-list > basiccard {
             display: flex;
+            flex-direction: column;
 
-            .bullet {
-                font-size: 10px;
-                margin: 5px 20px 0 0;
+            h3 {
+                order: -1;
             }
+        }
 
-            .number {
-                font-size: 14px;
-                margin: 2px 15px 0 0;
-
-                &:after {
-                    content: ".";
-                }
-            }
+        &.last-section .cards-list > * + * {
+            border-top: 1px solid $gray-6;
         }
     }
 

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -87,10 +87,6 @@
 }
 
 AllTopicsList .card {
-    .card-title .clamp-lines {
-        height: unset;
-    }
-
     .card-image {
         height: 150px;
     }

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -258,7 +258,8 @@ ResourceArticle LessonFrame {
     }
 }
 
-LessonFrame {
+LessonFrame,
+ActivityPage {
     ImageWrapper {
         position: relative;
 

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -382,6 +382,15 @@ test,
         margin-top: 20px;
     }
 
+    ol, ul {
+        padding-left: 0;
+        margin-left: 0;
+
+        li {
+            padding-left: 0;
+        }
+    }
+
     ol {
         align-self: start;
         flex: 1;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -14,8 +14,8 @@
 
 %bottom-swoop {
     background: $bottom-gradient;
-    -webkit-clip-path: ellipse(290% 100% at 50% 100%);
-    clip-path: ellipse(290% 100% at 50% 100%);
+    -webkit-clip-path: ellipse(2000px 100% at 50% 100%);
+    clip-path: ellipse(2000px 100% at 50% 100%);
     padding: 20px;
     margin: 0 -20px;
     width: 100%;

--- a/src/scss/_teaching.scss
+++ b/src/scss/_teaching.scss
@@ -3,7 +3,7 @@ TopicPage,
 Activitypage {
     .with-swoop {
         height: unset;
-        min-height: 150px;
+        min-height: 190px;
     }
 
     div.content-wrapper {

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -106,15 +106,24 @@ input[type="text"] {
 ul,
 ol {
     font-family: $app-typography;
-    padding-left: 0;
-    font-size: 13px;
+    padding-left: 20px;
+    line-height: 1.6;
+    font-size: 1em;
     color: $gray-3;
     font-weight: 300;
-    list-style-position: inside;
+}
+
+ol {
+    margin-left: 6px;
+}
+
+li {
+    padding-left: 6px;
 }
 
 li::marker {
     color: $gray-1;
+    font-size: 0.9em;
 }
 
 // lists within lists


### PR DESCRIPTION
Feedback from PeP people via Kara - Kara has a demo this Tuesday so would be great if these changes could be deployed to PeP by then.

Addresses #657 - though there are still a few things which need fixing (submitting the priority items in this PR in the interest of time)
[Full feedback doc is here](https://docs.google.com/document/d/1AmbCFXKOFQGTkwbHnnCsSjGNBJDP6gES3ClVQaqJnCQ/edit?usp=sharing)

Fixes a few styling bugs
- list styles in richtext now match the styles for list cards coming through from wagtail
- increase header image on learning activity detail screen
- make the card image heights on topics index more consistent
- adjust the bottom swoop value to be more consistent across pages
- links coming through from richtext now open in a new tab, if they are external sites
- correctly position the 'expand to full screen' button on images on activity cards, and adjust the border radius
- reorders the header/image for activity cards (so that the header is above the image)
