### PR TITLE
592 card height tweaks

### DIFF
--- a/src/riot/Components/LessonFrame.riot.html
+++ b/src/riot/Components/LessonFrame.riot.html
@@ -55,6 +55,10 @@
 
             userAgent() {
                 const { browser } = getPlatform();
+                // iphone 8+ and earlier models have a max height of 736;
+                if (window.innerHeight <= 736) {
+                    return `${browser.name.toLowerCase()} hasHomeButton`
+                }
                 return browser.name.toLowerCase();
             }
         };

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -69,6 +69,10 @@ LessonFrame {
 
         &.safari {
             height: calc(#{$base-card-height} - 100px);
+
+            &.hasHomeButton {
+                height: calc(#{$base-card-height} - 85px);
+            }
         }
 
         &.chrome,

--- a/src/scss/_resource_article.scss
+++ b/src/scss/_resource_article.scss
@@ -18,6 +18,10 @@ ResourceArticle {
         }
     }
 
+    .frame-background {
+        height: calc(100vh - (#{$top-menu-height} * 2)) !important;
+    }
+
     .content-block + .content-block {
         margin-top: 20px;
     }


### PR DESCRIPTION
the safari chaos continues!

available relative screen size is different for iphones with home buttons vs without.


iphone with no home button (swipe up to unlock):
<img src="https://user-images.githubusercontent.com/12974326/116836160-d51b8b00-ac08-11eb-9215-a9fa3daeab0d.PNG" width="250">


iphone with home button:
<img src="https://user-images.githubusercontent.com/12974326/116836164-d947a880-ac08-11eb-96ed-e6d2d9506201.jpeg" width="250">

previously looked like this:
<img src="https://user-images.githubusercontent.com/12974326/116836282-45c2a780-ac09-11eb-8906-b2191bcf8651.jpeg" width="250">

Resolutions [taken from here](https://www.paintcodeapp.com/news/ultimate-guide-to-iphone-resolutions) - this should work until apple decides to start downsizing screens


