### PR TITLE
CourseExam obeys routing

### DIFF
--- a/src/riot/Lesson/CourseExam.riot.html
+++ b/src/riot/Lesson/CourseExam.riot.html
@@ -1,5 +1,5 @@
 <CourseExam>
-    <template if="{ !state.results }">
+    <template if="{ stage === 'code' || !isNaN(cardNumber) }">
         <LessonFrame if="{ stage === 'code' && course.examType !== 'prelearning'}" linkTo="{ course.loc_hash }">
             <HonorCode minimumScore="{ course.minimumExamScore }"></HonorCode>
         </LessonFrame>
@@ -42,8 +42,9 @@
         </div>
     </template>
     <ExamResults
-        if="{ state.results }"
-        result="{ state.results }"
+        if="{ stage == 'result' }"
+        passed="{ state.result.passed }"
+        score="{ state.result.score }"
     ></ExamResults>
 
     <script>
@@ -57,7 +58,7 @@
         function CourseExam() {
             return {
                 state: {
-                    results: false,
+                    result: undefined,
                 },
 
                 TRANSLATIONS: {
@@ -109,7 +110,13 @@
                     if (result.error) {
                         alert('check you have answered all questions');
                     }
-                    this.update({results: result});
+                    this.update({
+                        result:{
+                            passed: result.passed,
+                            score: result.score,
+                        }
+                    });
+                    location.hash = `${this.course.loc_hash}:exam:result`;
                 },
 
                 hasAnswer() {

--- a/src/riot/Lesson/ExamResults.riot.html
+++ b/src/riot/Lesson/ExamResults.riot.html
@@ -1,6 +1,6 @@
 <ExamResults>
     <div class="congratulations-container">
-        <template if="{ course.examType === 'prelearning' || props.result.passed }">
+        <template if="{ course.examType === 'prelearning' || props.passed }">
             <span class="superman-success"></span>
             <h2>{ TRANSLATIONS.success() }</h2>
             <h3>{ TRANSLATIONS.completed() }</h3>
@@ -12,7 +12,7 @@
                 { TRANSLATIONS.resources() }
             </button>
         </template>
-        <template if="{ course.examType !== 'prelearning' && !props.result.passed}">
+        <template if="{ course.examType !== 'prelearning' && !props.passed}">
             <div>
                 <span class="incorrect-cross"></span>
                 <h2>{ TRANSLATIONS.notQuite() }</h2>
@@ -57,7 +57,7 @@
             },
 
             goToCourseExam() {
-                location.hash = `#${this.course.loc_hash}:exam:1`;
+                location.hash = `#${this.course.examLink}`;
             },
 
             passedExamMessage() {
@@ -70,7 +70,7 @@
 
                 return gettext(
                     "You passed this exam with a score of %1%. If you want to improve your score you can retake this exam.",
-                    Math.ceil(100 * this.props.result.score)
+                    Math.ceil(100 * this.props.score)
                 );
             },
 
@@ -78,7 +78,7 @@
                 // message when user did not pass exam
                 return gettext(
                     "You did not pass this assessment because you only scored %1% and you need to reach %2% to pass. You can retake this exam now or later.",
-                    Math.ceil(100 * this.props.result.score),
+                    Math.ceil(100 * this.props.score),
                     this.course.minimumExamScore
                 );
             },


### PR DESCRIPTION
The course exam set it's results state, and used that to display/hide results
It should have obeyed the routing instead and now does, passing score and passed
down to ExamResults as properties

Go to a course, finish all lessons, take the exam and fail
Click Retake exam, you should be taken back to the exam start code screen