### PR TITLE
useractions: fix :bug: , and store timestamps as integer (ms past unix epoch)

### DIFF
--- a/src/js/actions/ActionsStore.js
+++ b/src/js/actions/ActionsStore.js
@@ -33,7 +33,7 @@ export const EXAM_SCORE_TYPE = `${EXAM_ACTION_TYPE}.finalScore`;
 export const saveAndPostAction = (actionType, data) => {
     const action = {
         type: actionType,
-        date: new Date(),
+        date: new Date().valueOf(),
         uuid: make_uuid32(),
         ...data,
     };

--- a/src/js/actions/actions_idb.js
+++ b/src/js/actions/actions_idb.js
@@ -1,6 +1,7 @@
 import { openDB, deleteDB, wrap, unwrap } from "idb";
 
 const action_store_name = "actions";
+const ONE_YEAR = 365 * 24 * 60 * 60 * 1000
 
 // store an action of a certain type
 export async function writeAction(action) {
@@ -38,11 +39,8 @@ export async function ensureAction(action) {
     const transaction = actionsDb.transaction(action_store_name, "readwrite");
     const key = await transaction.store.getKey(action.uuid);
 
-    const thisYear = new Date().getFullYear();
-    const beginningOfThisYear = new Date(thisYear, 0, 1);
-
-    // return false - no change made; ignore actions from prior years.
-    if (key || action.date < beginningOfThisYear) {
+    // return false - no change made; ignore actions from more than a year ago
+    if (key || action.date < (new Date() - ONE_YEAR)) {
         return false;
     }
 

--- a/src/js/actions/actions_idb.js
+++ b/src/js/actions/actions_idb.js
@@ -1,7 +1,6 @@
 import { openDB, deleteDB, wrap, unwrap } from "idb";
 
 const action_store_name = "actions";
-const ONE_YEAR = 365 * 24 * 60 * 60 * 1000
 
 // store an action of a certain type
 export async function writeAction(action) {
@@ -39,10 +38,6 @@ export async function ensureAction(action) {
     const transaction = actionsDb.transaction(action_store_name, "readwrite");
     const key = await transaction.store.getKey(action.uuid);
 
-    // return false - no change made; ignore actions from more than a year ago
-    if (key || action.date < (new Date() - ONE_YEAR)) {
-        return false;
-    }
 
     action.synced = 1;
     await transaction.store.add(action);


### PR DESCRIPTION
- Fix bug where "one year ago" meant "one year ago" only *once a year*, on new year's eve.
- use unixtime milliseconds for the `date` timestamp (which should've been called `timestamp` imo); JS's `.toString()` is awful for storing datetimes, also if the browser locale is invariant, which it won't be. Any problem with this was swallowed away serverside as the timestamp would be replaced by the server's if the client-supplied timestamp couldn't be parsed, so we couldn't even see how often this went wrong; plus the origin information of the timestamp (server or client) was discarded. Working on fixing all that up in canoe-backend on the way to solidifying the ground for data analysis.