### PR TITLE
Replace check for existing action key

### DIFF
--- a/src/js/actions/actions_idb.js
+++ b/src/js/actions/actions_idb.js
@@ -38,6 +38,10 @@ export async function ensureAction(action) {
     const transaction = actionsDb.transaction(action_store_name, "readwrite");
     const key = await transaction.store.getKey(action.uuid);
 
+    // return false - already exists
+    if (key) {
+        return false;
+    }
 
     action.synced = 1;
     await transaction.store.add(action);


### PR DESCRIPTION
This got removed in a recent commit, we removed too much.
If the key exists in the db we should not try to write ( otherwise we get "key exists" errors )