### PR TITLE
prevent data overriding of metadata

### DIFF
--- a/src/js/actions/ActionsStore.js
+++ b/src/js/actions/ActionsStore.js
@@ -32,10 +32,10 @@ export const EXAM_SCORE_TYPE = `${EXAM_ACTION_TYPE}.finalScore`;
  */
 export const saveAndPostAction = (actionType, data) => {
     const action = {
+        ...data,
         type: actionType,
         date: new Date().valueOf(),
         uuid: make_uuid32(),
-        ...data,
     };
 
     // asnchronous persist


### PR DESCRIPTION
It appeared some callers of `saveAndPostAction` are passing event timestamps in their event data, overriding the formal timestamping done in `saveAndPostAction`. It'd be better if the timestamps, their format, and other metadata is decided upon in one place. So in this PR that place becomes `saveAndPostAction`, authoritatively.

I haven't seen any legitimate use of the overriding that in this PR has become impossible, but I'm not that familiar with this project — maybe someone else knows why timestamps were being set in two places on the same path.

A possible improvement might be to log a warning upon stumbling upon metadata fields in the payload, so that users of `saveAndPostAction` become better informed about expectations.