### PR TITLE
Handling some errors

### DIFF
--- a/src/js/Routing.js
+++ b/src/js/Routing.js
@@ -49,7 +49,14 @@ async function route(hashWith) {
         try {
             manifest = await getValidManifest();
         } catch (err) {
-            route = {page: {type: "manifest_error", error: `Manifest retrieval failure. Error: ${err}`}};
+            setRoute({
+                page: {
+                    type: "error",
+                    errorType: "no_manifest",
+                    error: err,
+                }
+            });
+            return;
         }
         if( !isAuthenticated() && REQUIRE_LOGIN )
         { 
@@ -73,7 +80,16 @@ async function route(hashWith) {
                 });
             } else {
                 // If we are a shortcut get the first page of that type from the manifest
-                page = manifest.getPageManifestData(pageHash);
+                try {
+                    page = manifest.getPageManifestData(pageHash);
+                } catch(err) {
+                    setRoute({
+                        page: {
+                            type: "error",
+                            errorType: "not_found",
+                        }
+                    });
+                }
             }
             route = !!page 
                 ? {page, riotHash}

--- a/src/riot/App.riot.html
+++ b/src/riot/App.riot.html
@@ -11,7 +11,6 @@
 
         <HandleError
             if="{ state.page.type === 'error' }"
-            error="{ state.page.error }"
         ></HandleError>
 
         <Login if="{state.page.type === 'login'}"></Login>

--- a/src/riot/Components/HandleError.riot.html
+++ b/src/riot/Components/HandleError.riot.html
@@ -1,5 +1,6 @@
 <HandleError>
     <div class="error">
+        <h2>{ TRANSLATIONS.title() }</h2>
         <p>
             { message }
         </p>
@@ -10,6 +11,7 @@
 
         export default {
             TRANSLATIONS: {
+                title: () => gettext("Whoops! Something has gone wrong"),
                 no_manifest: () => gettext("Sorry, we cannot retrieve site content."),
                 not_found: () => gettext("Sorry, we cannot find this site content."),
                 unknown: () => gettext("Sorry, an unexpected error has occurred.")
@@ -26,10 +28,18 @@
 
     </script>
     <style>
+
+        handleerror {
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
         .error {
-            width: 200px;
-            padding-top: 50px;
+            padding: 50px;
             margin: auto;
+            text-align: center;
         }
     </style>
 </HandleError>

--- a/src/riot/Components/HandleError.riot.html
+++ b/src/riot/Components/HandleError.riot.html
@@ -1,14 +1,35 @@
 <HandleError>
-    <span class="logo">
-        { props.error }
-    </span>
+    <div class="error">
+        <p>
+            { message }
+        </p>
+    </div>
 
     <script>
+        import { getRoute } from "ReduxImpl/Interface";
 
-     export default {
-         onMounted(props, state) {
-             throw props.error;
-         }
-     }   
+        export default {
+            TRANSLATIONS: {
+                no_manifest: () => gettext("Sorry, we cannot retrieve site content."),
+                not_found: () => gettext("Sorry, we cannot find this site content."),
+                unknown: () => gettext("Sorry, an unexpected error has occurred.")
+            },
+
+            get error() {
+                return getRoute().page;
+            },
+            get message() {
+                const translation = this.TRANSLATIONS[this.error.errorType];
+                return translation ? translation() : this.TRANSLATIONS.unknown();
+            }
+        }
+
     </script>
+    <style>
+        .error {
+            width: 200px;
+            padding-top: 50px;
+            margin: auto;
+        }
+    </style>
 </HandleError>


### PR DESCRIPTION
fixes #675 but maybe needs more visual love

Handles and displays basic error messages for the following 2 errors

1. Manifest cannot be retrieved from the server or the cache ( turn your runserver off and empty your storage to reproduce )
2. Page cannot be found ( goto http://YOUR_FRONTEND_HOST:PORT#does_not_Exist to reproduce as long as you already have a manifest or your server is running )