### PR TITLE
Api call optimization

### DIFF
--- a/src/riot/Screens/Resources.riot.html
+++ b/src/riot/Screens/Resources.riot.html
@@ -35,14 +35,12 @@
                 class="resource-card"
                 href="#{resource.loc_hash}"
             >
-                <template if="{ resource.ready }">
-                    <span each="{card in resource.cards}">
-                        <p>{card.tag}</p>
-                        <span if="{resource.cards.length > 1}">,</span>
-                    </span>
-                </template>
-                <h5>{resource.title}</h5>
-                <h6 if="{ resource.ready }">{resource.description}</h6>
+                <span each="{ type in resource.cardTypes }">
+                    <p>{ type }</p>
+                    <span if="{ resource.cardTypes.length > 1 }">,</span>
+                </span>
+                <h5>{ resource.title }</h5>
+                <h6>{ resource.description }</h6>
             </a>
         </div>
         <p if="{ page.resources.length === 0}" class="no-resources">

--- a/src/ts/Implementations/Specific/Course.ts
+++ b/src/ts/Implementations/Specific/Course.ts
@@ -23,13 +23,13 @@ export default class Course extends Page {
         return this.childPages;
     }
     get hasExam(): boolean {
-        return this.examCards && !!this.examCards.length;
+        return this.manifestData.has_exam;
     }
     get examType(): string {
-        return this.storedData.exam_type;
+        return this.manifestData.exam_type;
     }
     get examIsPrelearning(): boolean {
-        return this.examCards && this.examType === "prelearning";
+        return this.hasExam && this.examType === "prelearning";
     }
     get examLink(): string {
         const startOrCode = this.examIsPrelearning ? 1 : "code";
@@ -157,15 +157,10 @@ export default class Course extends Page {
      */
     get progressValues(): ProgressValues {
         const values = super.progressValues;
-        if (!this.ready) {
-            // kick of an async prepare to get the exam data
-            this.prepare();
-            // return the progress without exam data
-            return values;
-        } else {
-            values.min += this.isExamFinished ? 1 : 0;
-            values.max += this.hasExam ? 1 : 0;
-            return values;
-        }
+        // if the exam is finished count it in the number done
+        values.min += this.isExamFinished ? 1 : 0;
+        // if the course has an exam count it in the number to do
+        values.max += this.hasExam ? 1 : 0;
+        return values;
     }
 }

--- a/src/ts/Implementations/Specific/Lesson.ts
+++ b/src/ts/Implementations/Specific/Lesson.ts
@@ -22,13 +22,6 @@ export default class Lesson extends Page {
     get ready(): boolean {
         return super.ready && this.course.ready;
     }
-    /**
-     * Prepare both this page and the parent course
-     */
-    async prepare(): Promise<void> {
-        await super.prepare();
-        return this.course.prepare();
-    }
 
     /**  We store the responses to any test cards with its completion */
     get completionData(): Record<string, any> {

--- a/src/ts/Implementations/Specific/Resource.ts
+++ b/src/ts/Implementations/Specific/Resource.ts
@@ -2,7 +2,11 @@ import { Page } from "../Page";
 
 export default class Resource extends Page {
     get description(): string {
-        return this.data.description;
+        return this.manifestData.data?.description;
+    }
+
+    get cardTypes(): string[] {
+        return this.manifestData.data?.card_types;
     }
 
     get cards(): any {


### PR DESCRIPTION
In conjunction with https://github.com/catalpainternational/canoe-backend/pull/193

Currently when you go to the Bero courses home, the app will call every course api to display the completion progress bars and styles, these changes men the course list loads much quicker.

Avoid api calls for course completion display to know if a course is complete we need to know if it has an exam, and if that exam is a prelearning survey, this makes sure those values are read from the manifest, not the individual page api, so the course list does not need to retrieve every course page api

Stop calling the course api to display the lesson. We used to have to know if a course had an exam or not to display the links at the completion of the lesson content, we don't need that anymore because the data is in the manifest

Show resource descriptions and card types immediately fixes #676