### PR TITLE
Lesson no longer needs course to be ready

### DIFF
--- a/src/ts/Implementations/Specific/Lesson.ts
+++ b/src/ts/Implementations/Specific/Lesson.ts
@@ -16,13 +16,6 @@ export default class Lesson extends Page {
         return this.storedData?.cards;
     }
 
-    /**
-     * a lesson needs its course to be ready
-     */
-    get ready(): boolean {
-        return super.ready && this.course.ready;
-    }
-
     /**  We store the responses to any test cards with its completion */
     get completionData(): Record<string, any> {
         const answers = getTestAnswers(this.id);


### PR DESCRIPTION
This was causing a refresh on a lesson page to show a blank screen.

