### PR TITLE
645: resources download tweaks

### DIFF
--- a/src/riot/Components/LessonDownload.riot.html
+++ b/src/riot/Components/LessonDownload.riot.html
@@ -1,14 +1,29 @@
-<LessonDownload class="download-block">
-    <p class="lesson-number">{props.itemIndex + 1}</p>
-    <p class="title">{props.contentItem.title}</p>
-    <div class="download-state" onclick="{toggleCached}">
-        <span if="{state.cached}" class="download-complete">
-            <span class="icon"></span>
-        </span>
-        <span if="{!state.cached}" class="{state.loading ? 'loading' : ''}">
-            <span class="download"></span>
-        </span>
-    </div>
+<LessonDownload class="{ props.iconOnly ? '' : 'download-block' }">
+    <template if="{!props.iconOnly}">
+        <p class="lesson-number">{props.itemIndex + 1}</p>
+        <p class="title">{props.contentItem.title}</p>
+        <div class="download-state" onclick="{toggleCached}">
+            <span if="{state.cached}" class="download-complete">
+                <span class="icon"></span>
+            </span>
+            <span if="{!state.cached}" class="{state.loading ? 'loading' : ''}">
+                <span class="download"></span>
+            </span>
+        </div>
+    </template>
+
+    <template if="{props.iconOnly}">
+        <div onclick="{ toggleCached }" class="download-button">
+            <template if="{ state.cached }">
+                <span class="download"></span>
+                <p>{ TRANSLATIONS.downloaded() }</p>
+            </template>
+            <template if="{ !state.cached }">
+                <span class="download gray"></span>
+                <p>{ TRANSLATIONS.make() }</p>
+            </template>
+        </div>
+    </template>
 
     <script>
         export default {
@@ -19,6 +34,8 @@
 
             TRANSLATIONS: {
                 issue: () => gettext("There was a problem downloading the content"),
+                make: () => gettext("Make offline"),
+                downloaded: () => gettext("Downloaded"),
             },
 
             onMounted(props, state) {

--- a/src/riot/Screens/Resources.riot.html
+++ b/src/riot/Screens/Resources.riot.html
@@ -1,20 +1,6 @@
 <Resources>
-    <template if="{state.showDownloadModal}">
-        <div class="modal-background fade"
-            onclick="{toggleDownloadModal}">
-        </div>
-        <div class="cross gray modal-close-btn"
-            onclick="{toggleDownloadModal}">
-        </div>
-    </template>
-
     <TopMenu extrastyleclasses="without-swoop">
         <h5>{ TRANSLATIONS.resources() }</h5>
-        <a if="{page.resources.length}"
-            class="top-icon right has-circle {state.cached ? 'course-download-complete' : ''}"
-            onclick="{toggleDownloadModal}">
-            <span class="download"></span>
-        </a>
     </TopMenu>
     <div if="{state.hash == null}" class="content-wrapper">
         <SearchBar
@@ -29,41 +15,34 @@
             selectedTags="{ state.selectedTags }"
         ></TagList>
         <div class="list-resources">
-            <a
+            <div
                 each="{resource in page.resources}"
                 if="{isResourceVisible(resource)}"
                 class="resource-card"
-                href="#{resource.loc_hash}"
             >
-                <span each="{ type in resource.cardTypes }">
-                    <p>{ type }</p>
-                    <span if="{ resource.cardTypes.length > 1 }">,</span>
-                </span>
-                <h5>{ resource.title }</h5>
-                <h6>{ resource.description }</h6>
-            </a>
+                <a href="#{resource.loc_hash}" class="resource-content">
+                    <span each="{ type in resource.cardTypes }">
+                        <p>{ type }</p>
+                        <span if="{ resource.cardTypes.length > 1 }">,</span>
+                    </span>
+                    <h5>{ resource.title }</h5>
+                    <h6>{ resource.description }</h6>
+                </a>
+                <LessonDownload
+                    iconOnly="{true}"
+                    contentItem="{resource}"
+                ></LessonDownload>
+            </div>
         </div>
         <p if="{ page.resources.length === 0}" class="no-resources">
             { TRANSLATIONS.noArticlesYet() }
         </p>
     </div>
 
-    <PopupModal if="{state.showDownloadModal}" togalModal="{toggleDownloadModal}">
-        <span class="download-course"></span>
-        <h3>{ TRANSLATIONS.download_resources() }</h3>
-        <!-- <button class="btn-primary" onclick="{downloadAllResources}">{ TRANSLATIONS.download_all() }</button> -->
-        <LessonDownload
-            each="{(resource, index) in page.resources}"
-            contentItem="{resource}"
-            itemIndex="{index}"
-        ></LessonDownload>
-    </PopupModal>
-
     <script>
         import TagList from "RiotTags/Components/TagList.riot.html";
         import SearchBar from "RiotTags/Components/SearchBar.riot.html";
         import TopMenu from "RiotTags/Components/TopMenu.riot.html";
-        import PopupModal from "RiotTags/Components/PopupModal.riot.html";
         import LessonDownload from "RiotTags/Components/LessonDownload.riot.html";
 
         import { getRoute } from "ReduxImpl/Interface";
@@ -78,7 +57,6 @@
                 selectedTags: [],
                 searchString: "",
                 isLoading: false,
-                showDonloadModal: false,
                 cached: false,
             },
 
@@ -86,15 +64,12 @@
                 taglist: TagList,
                 searchbar: SearchBar,
                 topmenu: TopMenu,
-                popupmodal: PopupModal,
                 lessondownload: LessonDownload,
             },
 
             TRANSLATIONS: {
                 resources: () => gettext("Resources"),
                 noArticlesYet: () => gettext("There are no resources yet. Check back soon!"),
-                download_resources: () => gettext("Make resources available offline"),
-                download_all: () => gettext("Download all resources"),
             },
 
             onBeforeMount() {
@@ -119,15 +94,6 @@
 
             submitSearch(searchString) {
                 this.update({ searchString });
-            },
-
-            toggleDownloadModal() {
-                this.update({showDownloadModal: !this.state.showDownloadModal});
-                document.body.classList.toggle('modal-open');
-            },
-
-            downloadAllResources() {
-                document.querySelectorAll('.download-state .download').forEach((it) => it.click());
             },
 
             isResourceVisible(resource) {

--- a/src/scss/_course.scss
+++ b/src/scss/_course.scss
@@ -152,4 +152,20 @@ Resources {
           100% { transform: rotate(360deg); }
         }
     }
+
+    .download-button {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 3px;
+        height: 100%;
+
+        p {
+            font-size: 0.5em;
+            text-align: center;
+            text-transform: uppercase;
+            color: $gray-4;
+        }
+    }
 }

--- a/src/scss/_images.scss
+++ b/src/scss/_images.scss
@@ -267,6 +267,10 @@
     width: 22px;
     margin-left: -2px;
     margin-top: -2px;
+
+    &.gray {
+        background: $gray-1;
+    }
 }
 
 .expand-arrows {

--- a/src/scss/_resources.scss
+++ b/src/scss/_resources.scss
@@ -17,44 +17,48 @@ Resources {
     }
 
     .list-resources {
-        display: flex;
-        flex-direction: column;
-
-        a.resource-card {
+        .resource-card {
             background-color: $gray-10;
             margin-bottom: 3px;
             padding: 12px 18px;
             height: 110px;
-            display: block;
+            display: grid;
+            grid-template-columns: calc(100% - 40px) 40px;
+            width: 100%;
             box-sizing: border-box;
 
-            h5 {
-                color: $gray-1;
-                font-size: 1em;
-                margin: 5px auto;
-            }
+            .resource-content {
+                display: block;
+                box-sizing: border-box;
 
-            h6 {
-                color: $gray-3;
-                font-size: 14px;
-                @extend %truncate-with-ellipsis;
-            }
-
-            p,
-            span {
-                color: $gray-4;
-                text-transform: uppercase;
-                font-size: 0.75em;
-                display: inline-block;
-                letter-spacing: 0.6px;
-
-                span {
-                    margin-right: 3px;
+                h5 {
+                    color: $gray-1;
+                    font-size: 1em;
+                    margin: 5px auto;
                 }
-            }
 
-            span:last-of-type span {
-                display: none;
+                h6 {
+                    color: $gray-3;
+                    font-size: 14px;
+                    @extend %truncate-with-ellipsis;
+                }
+
+                p,
+                span {
+                    color: $gray-4;
+                    text-transform: uppercase;
+                    font-size: 0.75em;
+                    display: inline-block;
+                    letter-spacing: 0.6px;
+
+                    span {
+                        margin-right: 3px;
+                    }
+                }
+
+                span:last-of-type span {
+                    display: none;
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #645 

- modify `LessonDownload` component for `iconOnly` option
- move resource download out of modal and into resource list

Design reference: https://projects.invisionapp.com/d/main/#/console/20251865/429853508/inspect

Before:
<img width="250" alt="Screen Shot 2021-05-27 at 4 33 22 pm" src="https://user-images.githubusercontent.com/12974326/119777274-451be900-bf09-11eb-8d24-20ac5fcf7c19.png">

After:
<img width="250" alt="Screen Shot 2021-05-27 at 4 31 15 pm" src="https://user-images.githubusercontent.com/12974326/119777297-4b11ca00-bf09-11eb-8446-8082efa22ce6.png">

