### PR TITLE
Moves credentials include to page and manifest, assets do not need cr…

### DIFF
--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -51,6 +51,7 @@ export class Manifest extends PublishableItem implements StorableItem {
      */
     get requestOptions(): RequestInit {
         const reqInit: any = {
+            credentials: "include",
             cache: "default", // manifest can be returned from cache ( has conditional handling )
         };
 

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -73,6 +73,7 @@ export class Page extends PublishableItem implements StorableItem {
      */
     get requestOptions(): RequestInit {
         const reqInit: any = {
+            credentials: "include",
             cache: "force-cache", // pages have version query params we can rely on the cache
         };
         return reqInit as RequestInit;

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -1,4 +1,3 @@
-import { BACKEND_BASE_URL } from "js/urls";
 import Logger from "../Logger";
 
 export enum UpdatePolicy {
@@ -33,10 +32,8 @@ export abstract class PublishableItem {
     getRequestOptions(): RequestInit {
         return Object.assign(
             {
-                credentials: "include",
                 mode: "cors",
                 method: "GET",
-                referrer: BACKEND_BASE_URL,
             },
             this.requestOptions
         );


### PR DESCRIPTION
This moves the `credentials: "include"` setting to the Page and Manifest specific requestOptions getters, so that the base  implementation in PublishableItem ( must rename this ) does not include credentials, so that Asset requests do not include credentials, they do not need credentials anyway.

This is in response to noticing that our change to add credentials to those requests broke our default nginx media file CORS configuration. The cors config has been updated to "fix" this on jid-staging, but this code change should allow us to deploy across all servers without making those config changes on all servers.

Alos removed the refferrer definition, I never did understand why that was there in the first place. The referrer should be the last site navigated to ( default ), not the backend url.