### PR TITLE
685: custom exam pass score

### DIFF
--- a/src/riot/Lesson/CourseExam.riot.html
+++ b/src/riot/Lesson/CourseExam.riot.html
@@ -1,7 +1,7 @@
 <CourseExam>
     <template if="{ stage === 'code' || !isNaN(cardNumber) }">
         <template if="{ stage === 'code' && course.examType !== 'prelearning'}">
-            <HonorCode minimumScore="{ course.minimumExamScore }"></HonorCode>
+            <HonorCode></HonorCode>
         </template>
         <LessonFrame
             if="{ !isNaN(cardNumber) }"

--- a/src/riot/Lesson/ExamResults.riot.html
+++ b/src/riot/Lesson/ExamResults.riot.html
@@ -90,7 +90,7 @@
                 return gettext(
                     "You did not pass this assessment because you only scored %1% and you need to reach %2% to pass. You can review your answers, retake this exam now, or finish it later.",
                     Math.ceil(100 * this.props.result.score),
-                    this.course.minimumExamScore
+                    this.course.minimumExamScorePercentage
                 );
             },
         };

--- a/src/riot/Lesson/HonorCode.riot.html
+++ b/src/riot/Lesson/HonorCode.riot.html
@@ -70,11 +70,10 @@
             },
 
             youMustScoreAtLeastMessage() {
-                const { minimumScore } = this.props;
                 // message for what percent a user must score to pass the exam
                 return gettext(
                     "To pass this exam you need to score <strong>%1% or higher</strong>",
-                    this.course.minimumExamScore
+                    this.course.minimumExamScorePercentage
                 );
             },
         };

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -648,6 +648,7 @@ ExamReview {
         align-items: center;
         text-align: center;
         height: 100%;
+        padding-bottom: 2em;
 
         h2,
         h3 {

--- a/src/ts/Implementations/Specific/Course.ts
+++ b/src/ts/Implementations/Specific/Course.ts
@@ -9,8 +9,6 @@ import { persistExamScore } from "js/actions/ExamScores";
 import Lesson from "./Lesson";
 import Answer from "../Answer";
 
-const EXAM_PASS_SCORE = 0.75;
-
 export default class Course extends Page {
     get discussions(): any {
         return this.storedData?.lessons.map((lesson: any) => ({
@@ -54,7 +52,7 @@ export default class Course extends Page {
         if (this.examIsPrelearning && score !== undefined) {
             return true;
         } else {
-            return score !== undefined && score > EXAM_PASS_SCORE;
+            return score !== undefined && score > this.minimumExamScore / 100;
         }
     }
 
@@ -146,15 +144,15 @@ export default class Course extends Page {
                     return [uuid, answer.current];
                 })
             ),
-            passed: score >= EXAM_PASS_SCORE,
+            passed: score >= this.minimumExamScore / 100,
             score,
             correctAnswers,
-            passScore: EXAM_PASS_SCORE,
+            passScore: this.minimumExamScore / 100,
         };
     }
 
     get minimumExamScore(): number {
-        return Math.ceil(EXAM_PASS_SCORE * 100);
+        return this.manifestData.data?.exam_pass_score;
     }
 
     /** the data to show in a progress bar for a course includes

--- a/src/ts/Implementations/Specific/Course.ts
+++ b/src/ts/Implementations/Specific/Course.ts
@@ -52,7 +52,7 @@ export default class Course extends Page {
         if (this.examIsPrelearning && score !== undefined) {
             return true;
         } else {
-            return score !== undefined && score > this.minimumExamScore / 100;
+            return score !== undefined && score > this.minimumExamScoreDecimal;
         }
     }
 
@@ -144,15 +144,19 @@ export default class Course extends Page {
                     return [uuid, answer.current];
                 })
             ),
-            passed: score >= this.minimumExamScore / 100,
+            passed: score >= this.minimumExamScoreDecimal,
             score,
             correctAnswers,
-            passScore: this.minimumExamScore / 100,
+            passScore: this.minimumExamScoreDecimal,
         };
     }
 
-    get minimumExamScore(): number {
-        return this.manifestData.data?.exam_pass_score;
+    get minimumExamScoreDecimal(): number {
+        return this.storedData.exam_pass_score / 100;
+    }
+
+    get minimumExamScorePercentage(): number {
+        return this.storedData.exam_pass_score;
     }
 
     /** the data to show in a progress bar for a course includes


### PR DESCRIPTION
Closes #685

Requires https://github.com/catalpainternational/canoe-backend/pull/205 in the backend

- handle new field `exam_pass_score` for course exam