### PR TITLE
684: additional tweaks for error page

### DIFF
--- a/src/riot/Components/BottomMenu.riot.html
+++ b/src/riot/Components/BottomMenu.riot.html
@@ -65,6 +65,11 @@
                     return false;
                 }
 
+                if (this.page.type === 'error') {
+                    if (this.page.errorType === 'not_found') return true;
+                    return false;
+                }
+
                 if (this.page.type === 'lessonpage' || this.page.type === 'tipspage') {
                     return false;
                 }


### PR DESCRIPTION
Closes #684 (again)

- hide bottom menu bar on error page (excepting not_found)