### PR TITLE
bugfix for rendering tip cards + style tweaks

### DIFF
--- a/src/riot/Teaching/FlashCard.riot.html
+++ b/src/riot/Teaching/FlashCard.riot.html
@@ -36,7 +36,7 @@
 			},
 
 			get cardImageUrl() {
-				return this.props && this.props.card.card_image
+				return this.props && this.props.card && this.props.card.card_image
 					? `${process.env.API_BASE_URL}${this.props.card.card_image}`
 					: undefined;
 			},

--- a/src/riot/Teaching/TabSection.riot.html
+++ b/src/riot/Teaching/TabSection.riot.html
@@ -35,9 +35,6 @@
                 html5card: Html5Card,
                 raw: Raw
             },
-			onBeforeMount(props, state) {
-                console.log(props);
-			},
         };
     </script>
 </TabSection>

--- a/src/scss/_activity.scss
+++ b/src/scss/_activity.scss
@@ -177,6 +177,7 @@ ActivityPage {
             .tip-image-wrap {
                 width: calc(100% + 2em);
                 margin-left: -1em;
+                margin-right: -1em;
                 margin-top: -1em;
                 border-radius: 8px 8px 0 0;
                 overflow: hidden;
@@ -187,6 +188,10 @@ ActivityPage {
             .tip-card-image {
                 width: 100%;
                 object-fit: cover;
+            }
+
+            .btn-primary {
+                margin-top: 1em;
             }
         }
 


### PR DESCRIPTION
Bug surfaced in sprint review just now - tip cards were failing with a `cannot read property 'card_image' of undefined` error

Getters don't seem to have access to `props` when a component initially loads, so we need to be really explicit when using props in  conditionals

Also adds some very minor tweaks to styles