### PR TITLE
update image reference for lesson complete page

### DIFF
--- a/src/riot/Lesson/LessonComplete.riot.html
+++ b/src/riot/Lesson/LessonComplete.riot.html
@@ -1,6 +1,6 @@
 <LessonComplete>
     <div class="congratulations-container">
-        <span if="{!props.isTipsPage}" class="superman-success"></span>
+        <span if="{!props.isTipsPage}" class="high-fivers"></span>
         <span if="{props.isTipsPage}" class="tip-completion"></span>
         <template if="{ props.isTipsPage }">
             <div>

--- a/src/scss/_images.scss
+++ b/src/scss/_images.scss
@@ -234,10 +234,11 @@
 
 .high-fivers {
     @include unmaskable-icons-shared("~img/high_fivers.png", contain);
-    height: 100%;
     width: 100%;
-    max-height: 200px;
+    height: 160px;
     display: inline-block;
+    margin-top: 2.5em;
+    margin-bottom: 1em;
 }
 
 .download-course {


### PR DESCRIPTION
Updates the image reference for lesson completion, so that we can override it in JID

Discussed in the comments of #671 

Before:
<img src="https://user-images.githubusercontent.com/12974326/121126642-d8d7a880-c86b-11eb-8ebc-a6ad99abce9e.png" width="250">

After:
<img src="https://user-images.githubusercontent.com/12974326/121126652-dc6b2f80-c86b-11eb-806f-9ed11850ecd1.png" width="250">
