### PR TITLE
724: external links should open in new tab

### DIFF
--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -149,3 +149,15 @@ export const hashString = (string) => {
     hash = hash < 0 ? Math.ceil(hash) : Math.floor(hash);
     return hash - Math.floor(hash / bit32) * bit32;
 }
+
+export const externalLinks = (parentElement) => {
+    // Set the target for all external links to "_blank"
+    const absolutePath = new RegExp('^(?:[a-z]+:)?//', 'i');
+    const links = [...parentElement.getElementsByTagName('a')];
+
+    links.forEach((link) => {
+        if (absolutePath.test(link.href)) {
+            link.target = "_blank"
+        }
+    })
+}

--- a/src/riot/Components/BasicCard.riot.html
+++ b/src/riot/Components/BasicCard.riot.html
@@ -11,6 +11,8 @@
 
     <script>
         import ImageWrapper from "RiotTags/Components/ImageWrapper.riot.html";
+        import { externalLinks } from "js/utilities";
+
         export default {
             components: {
                 imagewrapper: ImageWrapper,
@@ -18,14 +20,7 @@
 
             setInnerHTML() {
                 this.$(".richtext").innerHTML = this.props.card.content;
-                const absolutePath = new RegExp('^(?:[a-z]+:)?//', 'i');
-                const links = [...this.$('.richtext').getElementsByTagName('a')];
-
-                links.forEach((link) => {
-                    if (absolutePath.test(link.href)) {
-                        link.target = "_blank"
-                    }
-                })
+                externalLinks(this.$(".richtext"));
             },
 
             onMounted() {

--- a/src/riot/Components/Raw.riot.html
+++ b/src/riot/Components/Raw.riot.html
@@ -1,8 +1,11 @@
 <raw>
     <script>
+        import { externalLinks } from "js/utilities";
+
         export default {
             setInnerHTML() {
                 this.root.innerHTML = this.props.html || this.props.card.content;
+                externalLinks(this.root);
             },
 
             onMounted() {


### PR DESCRIPTION
Closes #724 

Opens external links in a new tab.

From what I can tell, the only way to add external links anywhere in wagtail is in the `raw (content)` and `basic` cards.

This was already implemented for basic cards, now it's in raw cards too.