### PR TITLE
Override toString (don't use `get str`)

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -15,12 +15,14 @@
                         <h5>ID:{statusListing.id} {statusListing.type}:{statusListing.title} <small>({statusListing.version})</small> </h5>
                     </div>
 
-                    <div class="sync-body">
-                        <span>Store URL:{ statusListing.url }</span>
+                    <div if="{statusListing.url === statusListing.cacheKey}" class="sync-body">
+                        <span><small>Store URL/Cache Key:</small> { statusListing.url }</span>
                     </div>
-
-                    <div class="sync-body">
-                        <span>Cache Key:{ statusListing.cacheKey }</span>
+                    <div if="{statusListing.url != statusListing.cacheKey}" class="sync-body">
+                        <span><small>Store URL:</small> { statusListing.url }</span>
+                    </div>
+                    <div if="{statusListing.url != statusListing.cacheKey}" class="sync-body">
+                        <span><small>Cache Key:</small> { statusListing.cacheKey }</span>
                     </div>
 
                     <div class="sync-body">

--- a/src/ts/AppDataStatus.ts
+++ b/src/ts/AppDataStatus.ts
@@ -1,5 +1,8 @@
 // import { TSubscriptions } from "./Types/CacheTypes";
-// import { TAppelflapResult } from "./Types/CanoeEnums";
+import {
+    // TAppelflapResult,
+    TItemType,
+} from "./Types/CanoeEnums";
 import { TWagtailPage } from "./Types/PageTypes";
 import { TItemListing } from "./Types/PublishableItemTypes";
 
@@ -57,7 +60,7 @@ export class AppDataStatus {
             url: this.manifest.url,
             cacheKey: this.manifest.cacheKey,
             version: this.manifest.version,
-            type: "manifest",
+            type: "manifest" as TItemType,
             isValid: this.manifest.isValid,
             isAvailableOffline: isAvailableOffline,
             isPublishable: this.manifest.isPublishable,
@@ -90,7 +93,7 @@ export class AppDataStatus {
             url: statusId,
             cacheKey: manifestPage.storage_container,
             version: manifestPage.version,
-            type: "page",
+            type: "page" as TItemType,
             isValid: isValid,
             isAvailableOffline: isAvailableOffline,
             isPublishable: isPublishable,

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -139,11 +139,9 @@ export class Asset extends PublishableItem {
         return this!.entry!.renditions;
     }
 
-    /**
-     * Description for log lines
-     */
-    get str(): string {
-        return `Asset ${this.id} in ${this.#page.str}`;
+    /** Description for log lines */
+    toString(): string {
+        return `Asset ${this.id} in ${this.#page.toString()}`;
     }
 
     /**

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -240,7 +240,8 @@ export class Manifest extends PublishableItem implements StorableItem {
             .includes(pageType);
     }
 
-    get str(): string {
+    /** Description for log lines */
+    toString(): string {
         return "Site Manifest";
     }
 }

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -102,7 +102,7 @@ export class Page extends PublishableItem implements StorableItem {
                 this.saveToStore(manifestData);
             })
             .catch((err) => {
-                logger.warn("%s:%s deserialize %o", this.str, this.url, err);
+                logger.warn("%s:%s deserialize %o", this, this.url, err);
                 throw new Error("Page failed to deserialize");
             });
     }
@@ -143,7 +143,7 @@ export class Page extends PublishableItem implements StorableItem {
     }
 
     get title(): string {
-        return this.manifestData?.title || "";
+        return this.manifestData?.title || this.toString() || "";
     }
 
     get loc_hash(): string {
@@ -224,7 +224,8 @@ export class Page extends PublishableItem implements StorableItem {
         return this.#id;
     }
 
-    get str(): string {
+    /** Description for log lines */
+    toString(): string {
         return `Page ${this.title}`;
     }
 


### PR DESCRIPTION
# Description

Minor fix changing custom `str` `get` accessor and replacing it by overriding `toString()`, which is the preferred Javascript approach for this kind of thing.

Plus two other very small tweaks in preparation for next step - which is exploring `Availability` value and determining if it is still relevant, before moving on to actual Publishing.