### PR TITLE
max-height for images with option to expand, hide footer when expanded

### DIFF
--- a/src/riot/Components/ImageWrapper.riot.html
+++ b/src/riot/Components/ImageWrapper.riot.html
@@ -62,6 +62,15 @@
                 },
 
                 toggleImageFullScreen() {
+                    // stacking rules mean we can't position the image over the top of the footer,
+                    // so we cheat by making the footer invisible when we're in full-screen mode
+                    const footerEl = document.getElementsByTagName('footer')[0];
+                    if (footerEl && footerEl.style.visibility !== 'hidden') {
+                        footerEl.style.visibility = 'hidden'
+                    } else {
+                        footerEl.style.visibility = '';
+                    }
+
                     this.update({ imageFullScreen: !this.state.imageFullScreen });
                 },
             }

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -278,6 +278,8 @@ ActivityPage {
         margin-right: -20px;
         margin-top: -30px;
         border-radius: 8px 8px 0 0;
+        max-height: 85vmin;
+        object-fit: cover;
     }
 
     img.richtext-image.full-screen {
@@ -319,6 +321,10 @@ ActivityPage {
         display: flex;
         align-items: center;
         justify-content: center;
+
+        > span {
+             mix-blend-mode: difference;
+        }
     }
 
     ImageWrapper .contract-button {
@@ -326,10 +332,6 @@ ActivityPage {
         position: fixed;
         top: 1em;
         right: 1em;
-
-        > span {
-             mix-blend-mode: difference;
-        }
     }
 }
 


### PR DESCRIPTION
Part of #662 

Set a max-height for images in cards, to save on vertical real estate for portrait images.


shorter in the card:
<img src="https://user-images.githubusercontent.com/12974326/121304289-81a30800-c93f-11eb-995a-ba0aa9954eff.png" width="250">

with option to expand and see full height of image:
<img src="https://user-images.githubusercontent.com/12974326/121304303-85368f00-c93f-11eb-8841-6a8812ef512a.png" width="250">


also fixes a bug i noticed on activity pages which had the footer on top of the full-screen image
