### PR TITLE
Use BACKEND_BASE_URL where possible

### DIFF
--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -88,7 +88,7 @@ export const getCardImageUrl = (link, imageUrl) => {
     const fallbackImg = stockImages[cardId % stockImages.length];
 
     return imageUrl
-        ? `${process.env.API_BASE_URL}${imageUrl}?cardImageFallback=${fallbackImg}`
+        ? `${BACKEND_BASE_URL}${imageUrl}?cardImageFallback=${fallbackImg}`
         : fallbackImg;
 };
 

--- a/src/riot/Teaching/FlashCard.riot.html
+++ b/src/riot/Teaching/FlashCard.riot.html
@@ -26,6 +26,8 @@
 
 	<script>
 		import ImageWrapper from "RiotTags/Components/ImageWrapper.riot.html";
+		import { BACKEND_BASE_URL } from "js/urls";
+
 		export default {
 			TRANSLATIONS: {
 				viewAll: () => gettext("View all tips"),
@@ -37,7 +39,7 @@
 
 			get cardImageUrl() {
 				return this.props && this.props.card && this.props.card.card_image
-					? `${process.env.API_BASE_URL}${this.props.card.card_image}`
+					? `${BACKEND_BASE_URL}${this.props.card.card_image}`
 					: undefined;
 			},
 

--- a/src/riot/WagtailPages/LessonPage.riot.html
+++ b/src/riot/WagtailPages/LessonPage.riot.html
@@ -27,6 +27,7 @@
     <script>
         import LessonFrame from "RiotTags/Components/LessonFrame.riot.html";
 
+        import { BACKEND_BASE_URL } from "js/urls";
         import { getRoute } from "ReduxImpl/Interface";
 
         function LessonPage() { return {
@@ -42,7 +43,7 @@
 
             get cardImageUrl() {
                 return this.lesson.cardImage
-                    ? `${process.env.API_BASE_URL}${this.lesson.cardImage}`
+                    ? `${BACKEND_BASE_URL}${this.lesson.cardImage}`
                     : undefined;
             },
 

--- a/src/ts/Discussion.ts
+++ b/src/ts/Discussion.ts
@@ -1,7 +1,9 @@
 import { v4 as uuidv4 } from "uuid";
 import Cookies from "js-cookie";
 
-const DISCUSSION_BASE_URL = `${process.env.API_BASE_URL}/discussion`;
+import { BACKEND_BASE_URL } from "js/urls";
+
+const DISCUSSION_BASE_URL = `${BACKEND_BASE_URL}/discussion`;
 
 export class Discussion {
     static CreateComment(


### PR DESCRIPTION
# Description

While doing work on restoring isAvailable it became apparent that `process.env.API_BASE_URL` was being used in several places when it should be `BACKEND_BASE_URL` everywhere except for the actual canoe-environment.js and the urls.js

This grabs the files that otherwise have nothing with the upcoming isAvailabile work and ensures they're standardised to `BACKEND_BASE_URL`