### PR TITLE
Get all the `url`s correct, critical for cache keys

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -15,13 +15,13 @@
                         <h5>ID:{statusListing.id} {statusListing.type}:{statusListing.title} <small>({statusListing.version})</small> </h5>
                     </div>
 
-                    <div if="{statusListing.url === statusListing.cacheKey}" class="sync-body">
-                        <span><small>Store URL/Cache Key:</small> { statusListing.url }</span>
+                    <div if="{statusListing.api_url === statusListing.cacheKey}" class="sync-body">
+                        <span><small>Store URL/Cache Key:</small> { statusListing.api_url }</span>
                     </div>
-                    <div if="{statusListing.url != statusListing.cacheKey}" class="sync-body">
-                        <span><small>Store URL:</small> { statusListing.url }</span>
+                    <div if="{statusListing.api_url != statusListing.cacheKey}" class="sync-body">
+                        <span><small>Store URL:</small> { statusListing.api_url }</span>
                     </div>
-                    <div if="{statusListing.url != statusListing.cacheKey}" class="sync-body">
+                    <div if="{statusListing.api_url != statusListing.cacheKey}" class="sync-body">
                         <span><small>Cache Key:</small> { statusListing.cacheKey }</span>
                     </div>
 

--- a/src/ts/AppDataStatus.ts
+++ b/src/ts/AppDataStatus.ts
@@ -8,10 +8,7 @@ import { TItemListing } from "./Types/PublishableItemTypes";
 
 // import { TPublishableItem } from "./Types/PublishableItemTypes";
 
-import {
-    CacheKeys,
-    // InitialiseFromCache
-} from "./Implementations/CacheItem";
+import { CacheKeys, InitialiseFromCache } from "./Implementations/CacheItem";
 // import {
 //     getSubscriptions,
 //     publishItem,
@@ -57,7 +54,7 @@ export class AppDataStatus {
 
         return {
             title: "manifest",
-            url: this.manifest.url,
+            api_url: this.manifest.api_url,
             cacheKey: this.manifest.cacheKey,
             version: this.manifest.version,
             type: "manifest" as TItemType,
@@ -90,7 +87,7 @@ export class AppDataStatus {
         // TODO: add code to get item status (isValid, etc.)
         return {
             title: manifestPage.title,
-            url: statusId,
+            api_url: statusId,
             cacheKey: manifestPage.storage_container,
             version: manifestPage.version,
             type: "page" as TItemType,

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -19,6 +19,8 @@ import {
 } from "../Constants";
 import { getBrowser } from "../PlatformDetection";
 
+import { BACKEND_BASE_URL } from "js/urls";
+
 // See ts/Typings for the type definitions for these imports
 
 /** This is a subjective in-order list of the above rendition IDs
@@ -67,76 +69,56 @@ export class Asset extends PublishableItem {
         this.#id = id;
     }
 
-    /**
-     * The platform specific media url of this asset item
-     */
-    get url(): string {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return Asset.url(this!.entry as TAssetEntry);
-    }
-
-    /**
-     * The platform specific media url of this asset item
-     */
-    static url(asset: TAssetEntry): string {
-        const assetPath = Asset.platformSpecificRendition(asset)?.path || "";
-        return assetPath
-            ? `${process.env.API_BASE_URL}/media/${assetPath}`
-            : "";
+    /** The platform specific media url of this asset item */
+    get api_url(): string {
+        const assetPath =
+            Asset.platformSpecificRendition(this.assetEntry)?.path || "";
+        return assetPath ? `/media/${assetPath}` : "";
     }
 
     /**
      * The cache in which the asset is stored
-     * Currently uses the page cache
+     * @remarks Currently uses the page cache
      */
     get cacheKey(): string {
         return this.#page.cacheKey;
     }
 
-    /**
-     * The options to make an asset request
-     */
+    /** The options to make an asset request */
     get requestOptions(): RequestInit {
         return {
             cache: "force-cache", // assets are (almost always) invariant on filename
         } as RequestInit;
     }
 
-    /**
-     * The data from the manifest about this asset
-     */
+    /** The data from the manifest about this asset */
     get entry(): TAssetEntry | undefined {
         if (!this.#entry) {
             this.#entry = this.#page.manifestData.assets.find(
                 (a: any) => a["id"] === this.#id
             );
         }
+
         return this.#entry;
     }
 
-    /**
-     * The id of this asset in the manifest page entry
-     */
+    /** The id of this asset in the manifest page entry */
     get id(): string {
         return this.#id;
     }
 
-    /**
-     * The type of this asset (image|video|audio)
-     */
+    /** The type of this asset (image|video|audio) */
     get type(): string | undefined {
         return this.entry?.type;
     }
 
-    /**
-     * Array of renditions for this asset
-     */
+    /** Array of renditions for this asset */
     get renditions(): Record<string, TRendition> {
         if (Object.keys(this?.entry?.renditions || {}).length === 0) {
             throw new Error("Renditions cannot be accessed");
         }
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return this!.entry!.renditions;
+        return this.assetEntry!.renditions;
     }
 
     /** Description for log lines */
@@ -144,15 +126,18 @@ export class Asset extends PublishableItem {
         return `Asset ${this.id} in ${this.#page.toString()}`;
     }
 
-    /**
-     * The appropriate rendition for the platform we are running on
-     */
+    /** The appropriate rendition for the platform we are running on */
     get platformSpecificRendition(): TRendition {
         if (Object.keys(this?.entry?.renditions || {}).length === 0) {
             throw new Error("Renditions cannot be accessed");
         }
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return Asset.platformSpecificRendition(this!.entry as TAssetEntry);
+        return Asset.platformSpecificRendition(this.assetEntry);
+    }
+
+    get assetEntry(): TAssetEntry {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return this!.entry as TAssetEntry;
     }
 
     static platformSpecificRendition(asset: TAssetEntry): TRendition {
@@ -265,11 +250,13 @@ export class Asset extends PublishableItem {
     get metadata(): Record<string, any> {
         return this.#page.manifest.storedData?.videometa[this.id];
     }
+
     get thumbnail(): string {
         return this.metadata && this.metadata.thumbnail
-            ? `${process.env.API_BASE_URL}/${this.metadata.thumbnail}`
+            ? `${BACKEND_BASE_URL}/${this.metadata.thumbnail}`
             : "";
     }
+
     get duration(): number {
         return this.metadata && this.metadata.duration
             ? this.metadata.duration

--- a/src/ts/Implementations/CacheItem.ts
+++ b/src/ts/Implementations/CacheItem.ts
@@ -1,7 +1,7 @@
 import { IPublishableItem } from "../Interfaces/PublishableItemInterfaces";
 
 // See ts/Typings for the type definitions for these imports
-import { BACKEND_BASE_URL } from "js/urls";
+// import { BACKEND_BASE_URL } from "js/urls";
 
 /** A collection of utility methods for working with manifest, pages and assets in the cache */
 
@@ -19,7 +19,7 @@ const AccessCache = async (cacheKey: string): Promise<Cache> => {
 };
 
 /** Build a request object we can use to fetch the item
- * The item must have a valid `fullUrl`
+ * The item must have a valid `url`
  */
 // const BuildRequestObject = (item: IPublishableItem): Request => {
 //     const headers: any = {
@@ -42,7 +42,7 @@ const AccessCache = async (cacheKey: string): Promise<Cache> => {
 //         referrer: BACKEND_BASE_URL,
 //     };
 
-//     return new Request(item.fullUrl, reqInit as RequestInit);
+//     return new Request(item.url, reqInit as RequestInit);
 // };
 
 /** Cleans the supplied request object and uses it to set the item's requestObject and requestObjectCleaned values */
@@ -84,118 +84,113 @@ const CleanRequestObject = (item: IPublishableItem, srcReq: Request): void => {
 };
 
 /** Get the Request Object from the currently cached item */
-// const GetRequestObject = async (
-//     item: IPublishableItem
-// ): Promise<Request | undefined> => {
-//     if (!item.fullUrl || item.fullUrl === "/") {
-//         // "The full url could not be determined for this item, it is not retrievable";
-//         return Promise.resolve(undefined);
-//     }
+const GetRequestObject = async (
+    item: IPublishableItem
+): Promise<Request | undefined> => {
+    if (!item.url || item.url === "/") {
+        // "The full url could not be determined for this item, it is not retrievable";
+        return Promise.resolve(undefined);
+    }
 
-//     const itemCache = await AccessCache(item.cacheKey);
+    const itemCache = await AccessCache(item.cacheKey);
 
-//     const itemCacheState: Record<string, boolean> = {
-//         cacheExists: !!itemCache,
-//         reqObjectLoaded:
-//             item.isValid &&
-//             item.requestObject &&
-//             item.requestObject.url === item.fullUrl,
-//     };
+    const itemCacheState: Record<string, boolean> = {
+        cacheExists: !!itemCache,
+        reqObjectLoaded:
+            item.isValid &&
+            item.requestObject &&
+            item.requestObject.url === item.url,
+    };
 
-//     if (!itemCacheState.cacheExists) {
-//         // Couldn't get the cache open (this is a very unusual circumstance)
-//         if (!itemCacheState.reqObjectLoaded) {
-//             // And we don't have a pre-existing requestObject we can use
-//             return Promise.resolve(undefined);
-//         }
-//     }
+    if (!itemCacheState.cacheExists) {
+        // Couldn't get the cache open (this is a very unusual circumstance)
+        if (!itemCacheState.reqObjectLoaded) {
+            // And we don't have a pre-existing requestObject we can use
+            return Promise.resolve(undefined);
+        }
+    }
 
-//     const requests = await itemCache.keys(item.fullUrl, {
-//         ignoreMethod: true,
-//         ignoreSearch: true,
-//         ignoreVary: true,
-//     });
-//     itemCacheState["reqObjectInCache"] = requests.length > 0;
+    const requests = await itemCache.keys(item.url, {
+        ignoreMethod: true,
+        ignoreSearch: true,
+        ignoreVary: true,
+    });
+    itemCacheState["reqObjectInCache"] = requests.length > 0;
 
-//     if (!itemCacheState.reqObjectLoaded) {
-//         if (!itemCacheState.reqObjectInCache) {
-//             // `Could not find ${item.fullUrl} within the cache`;
-//             return Promise.resolve(undefined);
-//         } else {
-//             CleanRequestObject(item, item.requestObject);
-//             return item.requestObject;
-//         }
-//     }
+    if (!itemCacheState.reqObjectLoaded) {
+        if (!itemCacheState.reqObjectInCache) {
+            // `Could not find ${item.url} within the cache`;
+            return Promise.resolve(undefined);
+        } else {
+            CleanRequestObject(item, item.requestObject);
+            return item.requestObject;
+        }
+    }
 
-//     const orderedRequests: Request[] = ([] as Request[]).concat(requests);
-//     if (orderedRequests.length > 1) {
-//         // We should really clean the cache in this case
-//         orderedRequests.sort((a: Request, b: Request) => {
-//             return a.url < b.url ? 1 : -1;
-//         });
-//         orderedRequests.slice(1).forEach((request) => {
-//             itemCache.delete(request);
-//         });
-//     }
+    const orderedRequests: Request[] = ([] as Request[]).concat(requests);
+    if (orderedRequests.length > 1) {
+        // We should really clean the cache in this case
+        orderedRequests.sort((a: Request, b: Request) => {
+            return a.url < b.url ? 1 : -1;
+        });
+        orderedRequests.slice(1).forEach((request) => {
+            itemCache.delete(request);
+        });
+    }
 
-//     // Note: this is a side-effect behaviour, we try and load the previous
-//     // response headers from the cache so that we can (potentially) re-use them later
-//     const response = await itemCache.match(orderedRequests[0]);
-//     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-//     item.SetResponseHeaders(response!.headers);
+    // Note: this is a side-effect behaviour, we try and load the previous
+    // response headers from the cache so that we can (potentially) re-use them later
+    const response = await itemCache.match(orderedRequests[0]);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    item.SetResponseHeaders(response!.headers);
 
-//     CleanRequestObject(item, requests[0]);
-//     return item.requestObject;
-// };
+    CleanRequestObject(item, requests[0]);
+    return item.requestObject;
+};
 
 /** Get the item from the cache */
-// const GetFromCache = async (
-//     item: IPublishableItem
-// ): Promise<Response | undefined> => {
-//     const itemCache = await AccessCache(item.cacheKey);
+const GetFromCache = async (
+    item: IPublishableItem
+): Promise<Response | undefined> => {
+    const itemCache = await AccessCache(item.cacheKey);
 
-//     if (!item.requestObject || !itemCache) {
-//         return undefined;
-//     }
+    if (!item.requestObject || !itemCache) {
+        return undefined;
+    }
 
-//     return item.requestObject && !!itemCache
-//         ? await itemCache.match(item.requestObject)
-//         : undefined;
-// };
+    return item.requestObject && !!itemCache
+        ? await itemCache.match(item.requestObject)
+        : undefined;
+};
 
 /** Initialise this item from the cache */
-// export const InitialiseFromCache = async (
-//     item: IPublishableItem
-// ): Promise<boolean> => {
-//     const itemCache = await AccessCache(item.cacheKey);
-//     if (!itemCache || !item.api_url) {
-//         item.status.cacheStatus = "prepared";
-//         return false;
-//     }
+export const InitialiseFromCache = async (
+    item: IPublishableItem
+): Promise<boolean> => {
+    const itemCache = await AccessCache(item.cacheKey);
+    if (!itemCache || !item.api_url) {
+        return false;
+    }
 
-//     const reqObj = await GetRequestObject(item);
-//     if (!reqObj) {
-//         item.status.cacheStatus = "prepared";
-//         return false;
-//     }
-//     const reqUrl = new URL(reqObj.url);
-//     const params = reqUrl.searchParams;
-//     const version = parseInt(params.get("version") || "-1");
-//     item.version = isNaN(version) ? -1 : version;
+    const reqObj = await GetRequestObject(item);
+    if (!reqObj) {
+        return false;
+    }
+    const reqUrl = new URL(reqObj.url);
+    const params = reqUrl.searchParams;
+    const version = parseInt(params.get("version") || "-1");
+    item.version = isNaN(version) ? -1 : version;
 
-//     item.status.cacheStatus = "loading";
-//     const response = (await GetFromCache(item))?.clone();
+    const response = (await GetFromCache(item))?.clone();
 
-//     if (!response) {
-//         item.status.cacheStatus = "prepared";
-//         return false;
-//     }
+    if (!response) {
+        return false;
+    }
 
-//     const isInitialised = await item.initialiseFromResponse(response);
-//     item.status.cacheStatus = isInitialised ? "ready" : "loading";
+    const isInitialised = await item.initialiseFromResponse(response);
 
-//     return isInitialised;
-// };
+    return isInitialised;
+};
 
 /** Initialise this item from a network request */
 // export const InitialiseByRequest = async (
@@ -210,11 +205,11 @@ const CleanRequestObject = (item: IPublishableItem, srcReq: Request): void => {
 
 //     let reqObj = await GetRequestObject(item);
 //     if (!reqObj) {
-//         if (item.fullUrl && item.fullUrl !== "/") {
+//         if (item.url && item.url !== "/") {
 //             reqObj = BuildRequestObject(item);
 //             CleanRequestObject(item, reqObj);
 //         } else {
-//             // Without a fullUrl we cannot retrieve this item
+//             // Without a url we cannot retrieve this item
 //             // from either the cache or the network
 //             return false;
 //         }
@@ -232,7 +227,7 @@ const CleanRequestObject = (item: IPublishableItem, srcReq: Request): void => {
 //         //   (in which case the reported status is always 0.)
 //         // eslint-disable-next-line no-console
 //         console.error(
-//             `Error trying to add ${item.cacheKey} for ${item.fullUrl}.`
+//             `Error trying to add ${item.cacheKey} for ${item.url}.`
 //         );
 //         // eslint-disable-next-line no-console
 //         console.error(tex);
@@ -255,11 +250,11 @@ const CleanRequestObject = (item: IPublishableItem, srcReq: Request): void => {
 
 //     let reqObj = await GetRequestObject(item);
 //     if (!reqObj) {
-//         if (item.fullUrl && item.fullUrl !== "/") {
+//         if (item.url && item.url !== "/") {
 //             reqObj = BuildRequestObject(item);
 //             CleanRequestObject(item, reqObj);
 //         } else {
-//             // Without a fullUrl we cannot retrieve this item
+//             // Without a url we cannot retrieve this item
 //             // from either the cache or the network
 //             return false;
 //         }

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -16,8 +16,6 @@ import TeachingRoot from "./Specific/TeachingRoot";
 import TeachingTopic from "./Specific/TeachingTopic";
 import TeachingActivity from "./Specific/TeachingActivity";
 
-// See ts/Typings for the type definitions for these imports
-import { ROUTES_FOR_REGISTRATION } from "js/urls";
 import { storeManifest, getManifestFromStore } from "ReduxImpl/Interface";
 
 const logger = new Logger("Manifest");
@@ -29,26 +27,20 @@ class ManifestError extends Error {
     }
 }
 
-export const ManifestAPIURL = `${process.env.API_BASE_URL}/manifest/v1`;
-export const ManifestCacheKey = "canoe-manifest";
+export const ManifestAPIURL = "/manifest/v1";
+export const ManifestCacheKey = "bero-manifest";
 
 export class Manifest extends PublishableItem implements StorableItem {
-    /**
-     * The api url of the manifest
-     */
-    get url(): string {
+    get api_url(): string {
         return ManifestAPIURL;
     }
-    /**
-     * The cache in which the manifest is stored
-     */
+
+    /** The cache in which the manifest is stored */
     get cacheKey(): string {
         return ManifestCacheKey;
     }
 
-    /**
-     * The options to make a manifest request
-     */
+    /** The options to make a manifest request */
     get requestOptions(): RequestInit {
         const reqInit: any = {
             credentials: "include",
@@ -102,10 +94,6 @@ export class Manifest extends PublishableItem implements StorableItem {
 
     get version(): number {
         return this.storedData?.version || -1;
-    }
-
-    get fullUrl(): string {
-        return ROUTES_FOR_REGISTRATION.manifest;
     }
 
     get contentType(): string {

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -47,11 +47,8 @@ export class Page extends PublishableItem implements StorableItem {
         this.#parent = parent;
     }
 
-    /**
-     * The api url of this page
-     */
-    get url(): string {
-        return `${process.env.API_BASE_URL}${this.manifestData?.api_url}`;
+    get api_url(): string {
+        return this.manifestData?.api_url || "";
     }
 
     /**

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -1,3 +1,4 @@
+import { BACKEND_BASE_URL } from "js/urls";
 import Logger from "../Logger";
 
 export enum UpdatePolicy {
@@ -9,15 +10,20 @@ export enum UpdatePolicy {
 const logger = new Logger("ContentItem");
 
 /** A network backed content item that can be stored and retrieved from a named cache
- * The item can be queeried for cache status and added and remove from the cache
+ * @remarks The item can be queried for cache status and added and removed from the cache
  */
 export abstract class PublishableItem {
-    /** The url to retrieve this item from */
-    abstract get url(): string;
+    /** The api_url of this item as recorded in the manifest */
+    abstract get api_url(): string;
     /** The name of the cache used to store this item */
     abstract get cacheKey(): string;
     /** Request options dict used to retrieve this item */
     abstract get requestOptions(): RequestInit;
+
+    /** The (full) url to retrieve this item from */
+    get url(): string {
+        return this.api_url ? `${BACKEND_BASE_URL}${this.api_url}` : "";
+    }
 
     /** The options used to query the caches for this item */
     get cacheOptions(): MultiCacheQueryOptions {
@@ -130,7 +136,7 @@ export abstract class PublishableItem {
 
     /**
      * Check if the item is in the correct cache
-     * @returns true if this item is cached in the correct cache , false if not
+     * @returns true if this item is cached in the correct cache, false if not
      */
     async isAvailableOffline(): Promise<boolean> {
         const match = await caches.match(this.url, this.cacheOptions);
@@ -139,7 +145,7 @@ export abstract class PublishableItem {
 
     /**
      * Add this item to the correct cache
-     * @returns true if succeeds
+     * @returns true on success
      */
     async makeAvailableOffline(): Promise<boolean> {
         await this.getResponseFromNetwork();
@@ -148,7 +154,7 @@ export abstract class PublishableItem {
 
     /**
      * Remove this content from the cache
-     * @returns true if succeds
+     * @returns true on success
      */
     async removeAvailableOffline(): Promise<boolean> {
         const cache = await caches.open(this.cacheKey);

--- a/src/ts/Interfaces/PublishableItemInterfaces.ts
+++ b/src/ts/Interfaces/PublishableItemInterfaces.ts
@@ -1,4 +1,4 @@
-import { TPublishableItem } from "ts/Types/PublishableItemTypes";
+import { TPublishableItem } from "../Types/PublishableItemTypes";
 
 export interface IPublishableItem extends TPublishableItem {
     /** The original request object (stripped of any authentication values) that works as the key into the cache for this item */

--- a/src/ts/Types/PageTypes.ts
+++ b/src/ts/Types/PageTypes.ts
@@ -1,16 +1,22 @@
-import { TPageType } from "ts/Types/CanoeEnums";
-import { TItemCommon, TPublishableItem } from "ts/Types/PublishableItemTypes";
-import { TAssetEntry } from "ts/Types/AssetTypes";
+import { TPageType } from "./CanoeEnums";
+import { TItemCommon, TPublishableItem } from "./PublishableItemTypes";
+import { TAssetEntry } from "./AssetTypes";
 
 export type TPageData = {
+    title: string;
+    type: TPageType | string;
     loc_hash: string;
     storage_container: string;
-    assets: Array<TAssetEntry>;
+    version: number;
+    slug: string;
+    api_url: string;
     language: string;
     children: Array<string>;
     depth: number;
-    type: TPageType | string;
-    title: string;
+    card_image: string;
+    tags: Array<string>;
+    revision_id: BigInteger;
+    assets: Array<TAssetEntry>;
 } & TItemCommon;
 
 export type TPage = TPageData & TPublishableItem;

--- a/src/ts/Types/PublishableItemTypes.ts
+++ b/src/ts/Types/PublishableItemTypes.ts
@@ -1,12 +1,8 @@
-import {
-    TItemCacheStatus,
-    TItemStoreStatus,
-    TItemType,
-} from "ts/Types/CanoeEnums";
+import { TItemType } from "./CanoeEnums";
 
 /** The id fields for a manifest, page or asset item */
 export type TItemId = {
-    url: string;
+    api_url: string;
 };
 
 /** Describes the common fields for a manifest, page or asset item */


### PR DESCRIPTION
# Description

Over time the member `fullUrl` largely got replaced with just `url`, and `api_url` got a little lost along the way.

This just gets them all refreshed.

There is also some cleaning up of JSDoc comments (saving a few lines here and there).

This is part of the work towards `isAvailability` and then `isPublishable` (i.e. syncing)