### PR TITLE
Clean TS imports and JSDoc

### DIFF
--- a/src/ts/CacheSubscribe.ts
+++ b/src/ts/CacheSubscribe.ts
@@ -1,6 +1,6 @@
-import { TSubscriptions } from "ts/Types/CacheTypes";
+import { TSubscriptions } from "./Types/CacheTypes";
 
-import { AppelflapConnect } from "ts/AppelflapConnect";
+import { AppelflapConnect } from "./AppelflapConnect";
 
 export class CacheSubscribe {
     #subscriptions: TSubscriptions = { origins: {} };

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -88,7 +88,7 @@ export class Asset extends PublishableItem {
         return this.#page.cacheKey;
     }
 
-    /** The options to make an asset request*/
+    /** The options to make an asset request */
     get requestOptions(): RequestInit {
         return {
             cache: "force-cache", // assets are (almost always) invariant on filename

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -46,8 +46,7 @@ const RENDITION_PREFERENCE = [
  * whereby we will take the preferred rendition over the smallest rendition */
 const SIZE_DIFF_PERCENT = 0.02;
 
-/** A asset ( binary resource ) than can be cached
- */
+/** A asset ( binary resource ) than can be cached */
 export class Asset extends PublishableItem {
     /** id of this asset in the manifest page */
     #id: string;
@@ -67,17 +66,13 @@ export class Asset extends PublishableItem {
         this.#id = id;
     }
 
-    /**
-     * The platform specific media url of this asset item
-     */
+    /** The platform specific media url of this asset item */
     get url(): string {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return Asset.url(this!.entry as TAssetEntry);
     }
 
-    /**
-     * The platform specific media url of this asset item
-     */
+    /** The platform specific media url of this asset item */
     static url(asset: TAssetEntry): string {
         const assetPath = Asset.platformSpecificRendition(asset)?.path || "";
         return assetPath
@@ -87,24 +82,20 @@ export class Asset extends PublishableItem {
 
     /**
      * The cache in which the asset is stored
-     * Currently uses the page cache
+     * @remarks Currently uses the page cache
      */
     get cacheKey(): string {
         return this.#page.cacheKey;
     }
 
-    /**
-     * The options to make an asset request
-     */
+    /** The options to make an asset request*/
     get requestOptions(): RequestInit {
         return {
             cache: "force-cache", // assets are (almost always) invariant on filename
         } as RequestInit;
     }
 
-    /**
-     * The data from the manifest about this asset
-     */
+    /** The data from the manifest about this asset */
     get entry(): TAssetEntry | undefined {
         if (!this.#entry) {
             this.#entry = this.#page.manifestData.assets.find(
@@ -114,23 +105,17 @@ export class Asset extends PublishableItem {
         return this.#entry;
     }
 
-    /**
-     * The id of this asset in the manifest page entry
-     */
+    /** The id of this asset in the manifest page entry */
     get id(): string {
         return this.#id;
     }
 
-    /**
-     * The type of this asset (image|video|audio)
-     */
+    /** The type of this asset (image|video|audio) */
     get type(): string | undefined {
         return this.entry?.type;
     }
 
-    /**
-     * Array of renditions for this asset
-     */
+    /** Array of renditions for this asset */
     get renditions(): Record<string, TRendition> {
         if (Object.keys(this?.entry?.renditions || {}).length === 0) {
             throw new Error("Renditions cannot be accessed");
@@ -139,16 +124,12 @@ export class Asset extends PublishableItem {
         return this!.entry!.renditions;
     }
 
-    /**
-     * Description for log lines
-     */
+    /** Description for log lines */
     get str(): string {
         return `Asset ${this.id} in ${this.#page.str}`;
     }
 
-    /**
-     * The appropriate rendition for the platform we are running on
-     */
+    /** The appropriate rendition for the platform we are running on */
     get platformSpecificRendition(): TRendition {
         if (Object.keys(this?.entry?.renditions || {}).length === 0) {
             throw new Error("Renditions cannot be accessed");
@@ -267,11 +248,13 @@ export class Asset extends PublishableItem {
     get metadata(): Record<string, any> {
         return this.#page.manifest.storedData?.videometa[this.id];
     }
+
     get thumbnail(): string {
         return this.metadata && this.metadata.thumbnail
             ? `${process.env.API_BASE_URL}/${this.metadata.thumbnail}`
             : "";
     }
+
     get duration(): number {
         return this.metadata && this.metadata.duration
             ? this.metadata.duration

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -46,7 +46,7 @@ const RENDITION_PREFERENCE = [
  * whereby we will take the preferred rendition over the smallest rendition */
 const SIZE_DIFF_PERCENT = 0.02;
 
-/** A asset ( binary resource ) than can be cached */
+/** An asset ( binary resource ) than can be cached */
 export class Asset extends PublishableItem {
     /** id of this asset in the manifest page */
     #id: string;

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -33,22 +33,17 @@ export const ManifestAPIURL = `${process.env.API_BASE_URL}/manifest/v1`;
 export const ManifestCacheKey = "canoe-manifest";
 
 export class Manifest extends PublishableItem implements StorableItem {
-    /**
-     * The api url of the manifest
-     */
+    /** The api url of the manifest */
     get url(): string {
         return ManifestAPIURL;
     }
-    /**
-     * The cache in which the manifest is stored
-     */
+
+    /** The cache in which the manifest is stored */
     get cacheKey(): string {
         return ManifestCacheKey;
     }
 
-    /**
-     * The options to make a manifest request
-     */
+    /** The options to make a manifest request */
     get requestOptions(): RequestInit {
         const reqInit: any = {
             credentials: "include",
@@ -58,7 +53,7 @@ export class Manifest extends PublishableItem implements StorableItem {
         return reqInit as RequestInit;
     }
 
-    /** StorableItem implementations */
+    // StorableItem implementations
     /** set the manifest data in the manifest store */
     saveToStore(data: TManifestData): void {
         storeManifest(data);
@@ -67,7 +62,7 @@ export class Manifest extends PublishableItem implements StorableItem {
     get storedData(): TManifestData | undefined {
         return getManifestFromStore();
     }
-    /** end StorableItem implementations */
+    // end StorableItem implementations
 
     async prepare(): Promise<void> {
         const response = await this.getResponse();
@@ -86,7 +81,6 @@ export class Manifest extends PublishableItem implements StorableItem {
                 throw new ManifestError("Mainfest failed to deserialize");
             });
     }
-    /** end StorableItem implementations */
 
     get data(): TManifestData | undefined {
         return this.storedData;

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -53,7 +53,7 @@ export class Manifest extends PublishableItem implements StorableItem {
         return reqInit as RequestInit;
     }
 
-    // StorableItem implementations
+    // #region StorableItem implementations
     /** set the manifest data in the manifest store */
     saveToStore(data: TManifestData): void {
         storeManifest(data);
@@ -62,7 +62,7 @@ export class Manifest extends PublishableItem implements StorableItem {
     get storedData(): TManifestData | undefined {
         return getManifestFromStore();
     }
-    // end StorableItem implementations
+    // #endregion StorableItem implementations
 
     async prepare(): Promise<void> {
         const response = await this.getResponse();

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -47,30 +47,22 @@ export class Page extends PublishableItem implements StorableItem {
         this.#parent = parent;
     }
 
-    /**
-     * The api url of this page
-     */
+    /** The api url of this page */
     get url(): string {
         return `${process.env.API_BASE_URL}${this.manifestData?.api_url}`;
     }
 
-    /**
-     * The cache in which the page is stored
-     */
+    /** The cache in which the page is stored */
     get cacheKey(): string {
         return this.manifestData?.storage_container;
     }
 
-    /**
-     * The wagtail page live_revision_id
-     */
+    /** The wagtail page live_revision_id */
     get revisionId(): BigInteger {
         return this.manifestData?.revision_id;
     }
 
-    /**
-     * The options to make an page api request
-     */
+    /** The options to make an page api request */
     get requestOptions(): RequestInit {
         const reqInit: any = {
             credentials: "include",
@@ -91,9 +83,7 @@ export class Page extends PublishableItem implements StorableItem {
     }
     // end StorableItem implementations
 
-    /**
-     * Get and store this page, used in routing
-     */
+    /** Get and store this page, used in routing */
     async prepare(): Promise<void> {
         const response = await this.getResponse();
         return response
@@ -108,7 +98,7 @@ export class Page extends PublishableItem implements StorableItem {
     }
 
     /** Is this item `ready` to be used now!?
-     * Has it been succesfully prepared?
+     * @remarks Has it been succesfully prepared?
      */
     get ready(): boolean {
         return this.storedData !== undefined;
@@ -120,7 +110,7 @@ export class Page extends PublishableItem implements StorableItem {
     }
 
     /** The data for this page as defined in the manifest
-     * legacy alias for manifestData
+     * @remarks legacy alias for manifestData
      */
     get data(): TWagtailPageData {
         return this.storedData || {};
@@ -213,8 +203,7 @@ export class Page extends PublishableItem implements StorableItem {
         );
     }
 
-    /** This will do a basic integrity check.
-     */
+    /** This will do a basic integrity check. */
     get isValid(): boolean {
         // Has the wagtail version of this page been loaded
         return !!this.manifestData;
@@ -230,7 +219,7 @@ export class Page extends PublishableItem implements StorableItem {
 
     /**
      * Check if the page is in the correct cache
-     * @returns true if this page, assets, and children is cached in the correct cache , false if not
+     * @returns `true` if this page, assets, and children is cached in the correct cache, `false` if not
      */
     async isAvailableOffline(): Promise<boolean> {
         const promises: Promise<boolean>[] = [
@@ -249,7 +238,7 @@ export class Page extends PublishableItem implements StorableItem {
 
     /**
      * Add this page, assets, and children to the correct cache
-     * @returns true if succeeds
+     * @returns `true` on success
      */
     async makeAvailableOffline(): Promise<boolean> {
         const promises: Promise<boolean>[] = [
@@ -268,7 +257,7 @@ export class Page extends PublishableItem implements StorableItem {
 
     /**
      * Remove this page, assets, and children from the cache
-     * @returns true if succeds
+     * @returns `true` on success
      */
     async removeAvailableOffline(): Promise<boolean> {
         const promises: Promise<boolean>[] = [
@@ -286,7 +275,7 @@ export class Page extends PublishableItem implements StorableItem {
     }
 
     /** A page isPublishable if it, and all of its assets, are publishable.
-     * That is, are they all present in this page's cache. */
+     * @remarks That is, are they all present in this page's cache. */
     isPublishable(): Promise<boolean> {
         const promises: Promise<boolean>[] = [
             ...this.manifestAssets.map((asset) => {
@@ -313,6 +302,7 @@ export class Page extends PublishableItem implements StorableItem {
         this.#completionData = {};
         return data;
     }
+
     /** sets a page as complete */
     set complete(complete: boolean) {
         const data = this.completionData;
@@ -323,10 +313,12 @@ export class Page extends PublishableItem implements StorableItem {
         // set in redux store
         storePageComplete(this.id, action.date, complete);
     }
+
     /** if a page has been marked as complete */
     get complete(): boolean {
         return this.completeDate !== undefined;
     }
+
     /** when a page was last marked as complete */
     get completeDate(): Date | undefined {
         return getStoredPageCompletionDate(this.id);
@@ -352,6 +344,7 @@ export class Page extends PublishableItem implements StorableItem {
             return "in-progress";
         }
     }
+
     /** the data to show in a progress bar for this page */
     get progressValues(): ProgressValues {
         return {

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -71,7 +71,7 @@ export class Page extends PublishableItem implements StorableItem {
         return reqInit as RequestInit;
     }
 
-    // StorableItem implementations
+    // #region StorableItem implementations
     /** Set the page data in the page store */
     saveToStore(data: TWagtailPageData): void {
         storePageData(this.#id, data);
@@ -81,7 +81,7 @@ export class Page extends PublishableItem implements StorableItem {
     get storedData(): TWagtailPageData {
         return getPageDataFromStore(this.#id);
     }
-    // end StorableItem implementations
+    // #endregion StorableItem implementations
 
     /** Get and store this page, used in routing */
     async prepare(): Promise<void> {

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -118,7 +118,7 @@ export abstract class PublishableItem {
 
     /**
      * Check if the item is in the correct cache
-     * @returns true if this item is cached in the correct cache , false if not
+     * @returns `true` if this item is cached in the correct cache, `false` if not
      */
     async isAvailableOffline(): Promise<boolean> {
         const match = await caches.match(this.url, this.cacheOptions);
@@ -127,7 +127,7 @@ export abstract class PublishableItem {
 
     /**
      * Add this item to the correct cache
-     * @returns true if succeeds
+     * @returns `true` on success
      */
     async makeAvailableOffline(): Promise<boolean> {
         await this.getResponseFromNetwork();
@@ -136,7 +136,7 @@ export abstract class PublishableItem {
 
     /**
      * Remove this content from the cache
-     * @returns true if succeds
+     * @returns `true` on success
      */
     async removeAvailableOffline(): Promise<boolean> {
         const cache = await caches.open(this.cacheKey);

--- a/src/ts/Implementations/Specific/Course.ts
+++ b/src/ts/Implementations/Specific/Course.ts
@@ -62,9 +62,9 @@ export default class Course extends Page {
         return this.tags.filter((tag: string) => tags.includes(tag)).length > 0;
     }
 
-    /**  If the course has ans exam we store
-     *     the child lessons in this course at the time
-     *     any exam responses with its completion */
+    /** If the course has ans exam we store
+     * - the child lessons in this course at the time
+     * - any exam responses with its completion */
     get completionData(): Record<string, any> {
         const courseData: Record<string, any> = {
             lessons: this.childPages.map((l) => {

--- a/src/ts/Interfaces/PublishableItemInterfaces.ts
+++ b/src/ts/Interfaces/PublishableItemInterfaces.ts
@@ -1,6 +1,6 @@
-import { TPublishableItem } from "ts/Types/PublishableItemTypes";
-import { TPage, TWagtailPage } from "ts/Types/PageTypes";
-import { TAssetEntry } from "ts/Types/AssetTypes";
+import { TPublishableItem } from "../Types/PublishableItemTypes";
+import { TPage, TWagtailPage } from "../Types/PageTypes";
+import { TAssetEntry } from "../Types/AssetTypes";
 
 export interface IPublishableItem extends TPublishableItem {
     /** The original request object (stripped of any authentication values) that works as the key into the cache for this item */

--- a/src/ts/Types/AssetTypes.ts
+++ b/src/ts/Types/AssetTypes.ts
@@ -1,4 +1,4 @@
-import { TItemCommon, TPublishableItem } from "ts/Types/PublishableItemTypes";
+import { TItemCommon, TPublishableItem } from "./PublishableItemTypes";
 
 export type TRendition = {
     /** Path to the asset rendition, a partial URL */

--- a/src/ts/Types/ManifestTypes.ts
+++ b/src/ts/Types/ManifestTypes.ts
@@ -1,5 +1,5 @@
-import { TWagtailPage } from "ts/Types/PageTypes";
-import { TItemCommon } from "ts/Types/PublishableItemTypes";
+import { TWagtailPage } from "./PageTypes";
+import { TItemCommon } from "./PublishableItemTypes";
 
 export type TManifestData = {
     pages: Record<string, TWagtailPage>;

--- a/src/ts/Types/PageTypes.ts
+++ b/src/ts/Types/PageTypes.ts
@@ -1,6 +1,6 @@
-import { TPageType } from "ts/Types/CanoeEnums";
-import { TItemCommon, TPublishableItem } from "ts/Types/PublishableItemTypes";
-import { TAssetEntry } from "ts/Types/AssetTypes";
+import { TPageType } from "./CanoeEnums";
+import { TItemCommon, TPublishableItem } from "./PublishableItemTypes";
+import { TAssetEntry } from "./AssetTypes";
 
 export type TPageData = {
     loc_hash: string;

--- a/src/ts/Types/PublishableItemTypes.ts
+++ b/src/ts/Types/PublishableItemTypes.ts
@@ -1,8 +1,4 @@
-import {
-    TItemCacheStatus,
-    TItemStoreStatus,
-    TItemType,
-} from "./CanoeEnums";
+import { TItemCacheStatus, TItemStoreStatus, TItemType } from "./CanoeEnums";
 
 /** The id fields for a manifest, page or asset item */
 export type TItemId = {

--- a/src/ts/Types/PublishableItemTypes.ts
+++ b/src/ts/Types/PublishableItemTypes.ts
@@ -2,7 +2,7 @@ import {
     TItemCacheStatus,
     TItemStoreStatus,
     TItemType,
-} from "ts/Types/CanoeEnums";
+} from "./CanoeEnums";
 
 /** The id fields for a manifest, page or asset item */
 export type TItemId = {

--- a/src/ts/tests/AppelflapConnect.test.ts
+++ b/src/ts/tests/AppelflapConnect.test.ts
@@ -6,12 +6,12 @@ global.atob = require("atob");
 
 import { buildFakeNavigator } from "./fakeNavigator";
 
-import { AppelflapConnect } from "ts/AppelflapConnect";
+import { AppelflapConnect } from "../AppelflapConnect";
 import {
     TCertificate,
     TPublication,
     TSubscriptions,
-} from "ts/Types/CacheTypes";
+} from "../Types/CacheTypes";
 
 /* eslint-disable prettier/prettier */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/ts/tests/fakeManifest.ts
+++ b/src/ts/tests/fakeManifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "ts/Implementations/Manifest";
+import { Manifest } from "../Implementations/Manifest";
 
 export function buildFakeManifest(): Manifest {
     const fakeMani = new Manifest();


### PR DESCRIPTION
# Description

Across the TypeScript code this cleans up the imports used, to ensure better intellisense in various IDEs.

The `ts` webpack src path is only retained for some of the JS code, Riot pages, and Typings. 

It also cleans up several JSDoc comments, ensuring consistent formatting and fixing some spelling mistakes and grammatical errors, this is primarily cosmetic, but it does mean that several of the comments will make more sense, again these turn up in intellisense in various editors.