### PR TITLE
Use BACKEND_BASE_URL

### DIFF
--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -88,7 +88,7 @@ export const getCardImageUrl = (link, imageUrl) => {
     const fallbackImg = stockImages[cardId % stockImages.length];
 
     return imageUrl
-        ? `${process.env.API_BASE_URL}${imageUrl}?cardImageFallback=${fallbackImg}`
+        ? `${BACKEND_BASE_URL}${imageUrl}?cardImageFallback=${fallbackImg}`
         : fallbackImg;
 };
 

--- a/src/riot/Teaching/FlashCard.riot.html
+++ b/src/riot/Teaching/FlashCard.riot.html
@@ -26,6 +26,8 @@
 
 	<script>
 		import ImageWrapper from "RiotTags/Components/ImageWrapper.riot.html";
+		import { BACKEND_BASE_URL } from "js/urls";
+
 		export default {
 			TRANSLATIONS: {
 				viewAll: () => gettext("View all tips"),
@@ -37,7 +39,7 @@
 
 			get cardImageUrl() {
 				return this.props && this.props.card && this.props.card.card_image
-					? `${process.env.API_BASE_URL}${this.props.card.card_image}`
+					? `${BACKEND_BASE_URL}${this.props.card.card_image}`
 					: undefined;
 			},
 

--- a/src/riot/WagtailPages/LessonPage.riot.html
+++ b/src/riot/WagtailPages/LessonPage.riot.html
@@ -27,6 +27,7 @@
     <script>
         import LessonFrame from "RiotTags/Components/LessonFrame.riot.html";
 
+        import { BACKEND_BASE_URL } from "js/urls";
         import { getRoute } from "ReduxImpl/Interface";
 
         function LessonPage() { return {
@@ -42,7 +43,7 @@
 
             get cardImageUrl() {
                 return this.lesson.cardImage
-                    ? `${process.env.API_BASE_URL}${this.lesson.cardImage}`
+                    ? `${BACKEND_BASE_URL}${this.lesson.cardImage}`
                     : undefined;
             },
 

--- a/src/ts/Discussion.ts
+++ b/src/ts/Discussion.ts
@@ -1,7 +1,9 @@
 import { v4 as uuidv4 } from "uuid";
 import Cookies from "js-cookie";
 
-const DISCUSSION_BASE_URL = `${process.env.API_BASE_URL}/discussion`;
+import { BACKEND_BASE_URL } from "js/urls";
+
+const DISCUSSION_BASE_URL = `${BACKEND_BASE_URL}/discussion`;
 
 export class Discussion {
     static CreateComment(

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -20,6 +20,7 @@ import {
 import { getBrowser } from "../PlatformDetection";
 
 // See ts/Typings for the type definitions for these imports
+import { BACKEND_BASE_URL } from "js/urls";
 
 /** This is a subjective in-order list of the above rendition IDs
  * Its intended use is to be intersected with an array of available renditions
@@ -80,9 +81,7 @@ export class Asset extends PublishableItem {
      */
     static url(asset: TAssetEntry): string {
         const assetPath = Asset.platformSpecificRendition(asset)?.path || "";
-        return assetPath
-            ? `${process.env.API_BASE_URL}/media/${assetPath}`
-            : "";
+        return assetPath ? `${BACKEND_BASE_URL}/media/${assetPath}` : "";
     }
 
     /**
@@ -269,7 +268,7 @@ export class Asset extends PublishableItem {
     }
     get thumbnail(): string {
         return this.metadata && this.metadata.thumbnail
-            ? `${process.env.API_BASE_URL}/${this.metadata.thumbnail}`
+            ? `${BACKEND_BASE_URL}/${this.metadata.thumbnail}`
             : "";
     }
     get duration(): number {

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -17,7 +17,7 @@ import TeachingTopic from "./Specific/TeachingTopic";
 import TeachingActivity from "./Specific/TeachingActivity";
 
 // See ts/Typings for the type definitions for these imports
-import { ROUTES_FOR_REGISTRATION } from "js/urls";
+import { BACKEND_BASE_URL, ROUTES_FOR_REGISTRATION } from "js/urls";
 import { storeManifest, getManifestFromStore } from "ReduxImpl/Interface";
 
 const logger = new Logger("Manifest");
@@ -29,7 +29,7 @@ class ManifestError extends Error {
     }
 }
 
-export const ManifestAPIURL = `${process.env.API_BASE_URL}/manifest/v1`;
+export const ManifestAPIURL = `${BACKEND_BASE_URL}/manifest/v1`;
 export const ManifestCacheKey = "canoe-manifest";
 
 export class Manifest extends PublishableItem implements StorableItem {

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -17,6 +17,7 @@ import {
 } from "ReduxImpl/Interface";
 import { persistCompletion } from "js/actions/Completion";
 import { persistFeedback } from "js/UserActions";
+import { BACKEND_BASE_URL } from "js/urls";
 
 const logger = new Logger("Page");
 
@@ -51,7 +52,7 @@ export class Page extends PublishableItem implements StorableItem {
      * The api url of this page
      */
     get url(): string {
-        return `${process.env.API_BASE_URL}${this.manifestData?.api_url}`;
+        return `${BACKEND_BASE_URL}${this.manifestData?.api_url}`;
     }
 
     /**


### PR DESCRIPTION
# Description

TypeScript doesn't like referencing the `process` in `process.env.API_BASE_URL` without the appropriate declarations.

Previously this was resolved by defining an alias `BACKEND_BASE_URL` and using that everywhere.  But along the way `process.env.API_BASE_URL` crept back in, there was even one file that used both terms.

This value is important in getting resources from the server, and therefore also in cache handling.  So this :pr: is simply about getting its usage consistent to make code review / exploration easier.