### PR TITLE
Use JS toString in preference to custom method

### DIFF
--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -125,8 +125,8 @@ export class Asset extends PublishableItem {
     }
 
     /** Description for log lines */
-    get str(): string {
-        return `Asset ${this.id} in ${this.#page.str}`;
+    toString(): string {
+        return `Asset ${this.id} in ${this.#page}`;
     }
 
     /** The appropriate rendition for the platform we are running on */

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -246,7 +246,9 @@ export class Manifest extends PublishableItem implements StorableItem {
             })
             .includes(pageType);
     }
-    get str(): string {
+
+    /** Description for log lines */
+    toString(): string {
         return "Site Manifest";
     }
 }

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -92,7 +92,7 @@ export class Page extends PublishableItem implements StorableItem {
                 this.saveToStore(manifestData);
             })
             .catch((err) => {
-                logger.warn("%s:%s deserialize %o", this.str, this.url, err);
+                logger.warn("%s:%s deserialize %o", this, this.url, err);
                 throw new Error("Page failed to deserialize");
             });
     }
@@ -133,7 +133,7 @@ export class Page extends PublishableItem implements StorableItem {
     }
 
     get title(): string {
-        return this.manifestData?.title || "";
+        return this.manifestData?.title || this.toString() || "";
     }
 
     get loc_hash(): string {
@@ -213,7 +213,8 @@ export class Page extends PublishableItem implements StorableItem {
         return this.#id;
     }
 
-    get str(): string {
+    /** Description for log lines */
+    toString(): string {
         return `Page ${this.title}`;
     }
 

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -134,7 +134,7 @@ export class Page extends PublishableItem implements StorableItem {
     }
 
     get title(): string {
-        return this.manifestData?.title || this.toString() || "";
+        return this.manifestData?.title || "";
     }
 
     get loc_hash(): string {

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -18,8 +18,6 @@ export abstract class PublishableItem {
     abstract get cacheKey(): string;
     /** Request options dict used to retrieve this item */
     abstract get requestOptions(): RequestInit;
-    /** Brief descriptive string for logs */
-    abstract get str(): string;
 
     /** The options used to query the caches for this item */
     get cacheOptions(): MultiCacheQueryOptions {
@@ -38,25 +36,33 @@ export abstract class PublishableItem {
             this.requestOptions
         );
     }
+
+    private logMessage(message: string): void {
+        logger.log("%s for %s:%s", message, this, this.url);
+    }
+
     /**
      * Get a network response for this item, caching it appropriately
      * @returns a request response for this item
      * @throws Error if network failure or response not OK
      */
     async getResponseFromNetwork(): Promise<Response> {
-        logger.log("using network for %s:%s", this.str, this.url);
+        this.logMessage("using network");
+
         let response;
         try {
             response = await fetch(this.url, this.getRequestOptions());
         } catch {
-            logger.warn("request failed for %s:%s", this.str, this.url);
+            this.logMessage("request failed");
             throw Error("Network error");
         }
+
         if (!response.ok) {
-            logger.warn("request not ok for %s:%s", this.str, this.url);
+            this.logMessage("request not ok");
             throw Error("Network response not ok");
         }
-        logger.log("caching response for %s:%s", this.str, this.url);
+
+        this.logMessage("caching response");
         const responseClone = response.clone();
         await caches
             .open(this.cacheKey)
@@ -70,15 +76,14 @@ export abstract class PublishableItem {
      * @throws Error if network used and failure or response not OK
      */
     async getResponseFromCache(): Promise<Response | undefined> {
-        logger.log("checking cache for %s:%s", this.str, this.url);
+        this.logMessage("checking cache");
+
         return caches
             .match(this.url, this.cacheOptions)
             .then((cacheResponse) => {
-                if (cacheResponse === undefined) {
-                    logger.log("Cache miss for %s:%s", this.str, this.url);
-                } else {
-                    logger.log("Use cache for %s:%s", this.str, this.url);
-                }
+                this.logMessage(
+                    cacheResponse === undefined ? "cache miss" : "use cache"
+                );
                 return cacheResponse;
             });
     }
@@ -93,7 +98,13 @@ export abstract class PublishableItem {
     async getResponse(
         updatePolicy: UpdatePolicy = UpdatePolicy.Default
     ): Promise<Response> {
-        logger.info("Get response for %s:%s using %s", this.str, updatePolicy);
+        logger.info(
+            "Get response for %s:%s using %s",
+            this,
+            this.url,
+            updatePolicy
+        );
+
         let response: Response;
         switch (updatePolicy) {
             case UpdatePolicy.Default:
@@ -113,6 +124,7 @@ export abstract class PublishableItem {
             default:
                 throw Error("Unhandled prepare strategy");
         }
+
         return response;
     }
 


### PR DESCRIPTION
# Description

JS has a property called `toString` which is what gets invoked whenever an object is 'dumped' as a string.

It is considered preferable to override this if a custom string representation is wanted for a certain object.

As we're using this for a lot of logging related to cache handling etc. it's also preferable to do this minor tweak.