### PR TITLE
404s without "#" in url render homepage instead of nginx default 404

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,7 @@ module.exports = env => {
         },
         devServer: {
             contentBase: path.resolve(__dirname, "dist"),
+            historyApiFallback: true,
         },
         resolve: {
             extensions: [".ts", ".js", ".cjs", ".mjs", ".json", ".riot.html"],


### PR DESCRIPTION
Rather than the default nginx 404 page, redirect the user to the homepage
<img width="250" alt="Screen Shot 2021-06-10 at 11 55 31 am" src="https://user-images.githubusercontent.com/12974326/121452454-c92ea000-c9e2-11eb-958f-b8f4f633d4a2.png">


This isn't _ideal_ behaviour, however it doesn't seem to be possible to redirect to a specific url (e.g. `#404` or `#not_found`).

Further, if you start with `http://127.0.0.1:8085/dsadjkls`  it’ll render the homepage, and then if you navigate anywhere the url keeps everything before the `#` and becomes  `http://127.0.0.1:8085/dsadjkls#resources`

I'll keep looking for a solution to direct them to an error screen, but this is an interim solution for a problem which probably won't really happen all that often anyway.
