### PR TITLE
url cleanup + pageType + manifest cacheKey

### DIFF
--- a/src/ts/AppDataStatus.ts
+++ b/src/ts/AppDataStatus.ts
@@ -57,7 +57,7 @@ export class AppDataStatus {
         return {
             id: this.manifest.id,
             title: "manifest",
-            api_url: this.manifest.api_url,
+            backendPath: this.manifest.backendPath,
             cacheKey: this.manifest.cacheKey,
             version: this.manifest.version,
             type: "manifest",
@@ -105,7 +105,7 @@ export class AppDataStatus {
         return {
             id: pageId,
             title: manifestPage.title,
-            api_url: statusId,
+            backendPath: statusId,
             cacheKey: manifestPage.storage_container,
             version: manifestPage.version,
             type: "page",

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -68,7 +68,7 @@ export class Asset extends PublishableItem {
     }
 
     /** The platform specific media url of this asset item */
-    get api_url(): string {
+    get backendPath(): string {
         const assetPath =
             Asset.platformSpecificRendition(this.assetEntry)?.path || "";
         return assetPath ? `/media/${assetPath}` : "";

--- a/src/ts/Implementations/Asset.ts
+++ b/src/ts/Implementations/Asset.ts
@@ -68,15 +68,10 @@ export class Asset extends PublishableItem {
     }
 
     /** The platform specific media url of this asset item */
-    get url(): string {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return Asset.url(this!.entry as TAssetEntry);
-    }
-
-    /** The platform specific media url of this asset item */
-    static url(asset: TAssetEntry): string {
-        const assetPath = Asset.platformSpecificRendition(asset)?.path || "";
-        return assetPath ? `${BACKEND_BASE_URL}/media/${assetPath}` : "";
+    get api_url(): string {
+        const assetPath =
+            Asset.platformSpecificRendition(this.assetEntry)?.path || "";
+        return assetPath ? `/media/${assetPath}` : "";
     }
 
     /**
@@ -120,7 +115,7 @@ export class Asset extends PublishableItem {
             throw new Error("Renditions cannot be accessed");
         }
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return this!.entry!.renditions;
+        return this.assetEntry!.renditions;
     }
 
     /** Description for log lines */
@@ -133,8 +128,12 @@ export class Asset extends PublishableItem {
         if (Object.keys(this?.entry?.renditions || {}).length === 0) {
             throw new Error("Renditions cannot be accessed");
         }
+        return Asset.platformSpecificRendition(this.assetEntry);
+    }
+
+    get assetEntry(): TAssetEntry {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return Asset.platformSpecificRendition(this!.entry as TAssetEntry);
+        return this!.entry as TAssetEntry;
     }
 
     static platformSpecificRendition(asset: TAssetEntry): TRendition {

--- a/src/ts/Implementations/CacheItem.ts
+++ b/src/ts/Implementations/CacheItem.ts
@@ -168,7 +168,7 @@ export const InitialiseFromCache = async (
     item: IPublishableItem
 ): Promise<boolean> => {
     const itemCache = await AccessCache(item.cacheKey);
-    if (!itemCache || !item.api_url) {
+    if (!itemCache || !item.backendPath) {
         item.status.cacheStatus = "prepared";
         return false;
     }

--- a/src/ts/Implementations/CacheItem.ts
+++ b/src/ts/Implementations/CacheItem.ts
@@ -19,7 +19,7 @@ const AccessCache = async (cacheKey: string): Promise<Cache> => {
 };
 
 /** Build a request object we can use to fetch the item
- * The item must have a valid `fullUrl`
+ * The item must have a valid `url`
  */
 const BuildRequestObject = (item: IPublishableItem): Request => {
     const headers: any = {
@@ -42,7 +42,7 @@ const BuildRequestObject = (item: IPublishableItem): Request => {
         referrer: BACKEND_BASE_URL,
     };
 
-    return new Request(item.fullUrl, reqInit as RequestInit);
+    return new Request(item.url, reqInit as RequestInit);
 };
 
 /** Cleans the supplied request object and uses it to set the item's requestObject and requestObjectCleaned values */
@@ -87,7 +87,7 @@ const CleanRequestObject = (item: IPublishableItem, srcReq: Request): void => {
 const GetRequestObject = async (
     item: IPublishableItem
 ): Promise<Request | undefined> => {
-    if (!item.fullUrl || item.fullUrl === "/") {
+    if (!item.url || item.url === "/") {
         // "The full url could not be determined for this item, it is not retrievable";
         return Promise.resolve(undefined);
     }
@@ -99,7 +99,7 @@ const GetRequestObject = async (
         reqObjectLoaded:
             item.isValid &&
             item.requestObject &&
-            item.requestObject.url === item.fullUrl,
+            item.requestObject.url === item.url,
     };
 
     if (!itemCacheState.cacheExists) {
@@ -110,7 +110,7 @@ const GetRequestObject = async (
         }
     }
 
-    const requests = await itemCache.keys(item.fullUrl, {
+    const requests = await itemCache.keys(item.url, {
         ignoreMethod: true,
         ignoreSearch: true,
         ignoreVary: true,
@@ -119,7 +119,7 @@ const GetRequestObject = async (
 
     if (!itemCacheState.reqObjectLoaded) {
         if (!itemCacheState.reqObjectInCache) {
-            // `Could not find ${item.fullUrl} within the cache`;
+            // `Could not find ${item.url} within the cache`;
             return Promise.resolve(undefined);
         } else {
             CleanRequestObject(item, item.requestObject);
@@ -214,11 +214,11 @@ export const InitialiseByRequest = async (
     let reqObj = await GetRequestObject(item);
     if (!reqObj) {
         item.status.cacheStatus = "prepared";
-        if (item.fullUrl && item.fullUrl !== "/") {
+        if (item.url && item.url !== "/") {
             reqObj = BuildRequestObject(item);
             CleanRequestObject(item, reqObj);
         } else {
-            // Without a fullUrl we cannot retrieve this item
+            // Without a full url we cannot retrieve this item
             // from either the cache or the network
             return false;
         }
@@ -235,9 +235,7 @@ export const InitialiseByRequest = async (
         // * request is a cross-origin no-cors request
         //   (in which case the reported status is always 0.)
         // eslint-disable-next-line no-console
-        console.error(
-            `Error trying to add ${item.cacheKey} for ${item.fullUrl}.`
-        );
+        console.error(`Error trying to add ${item.cacheKey} for ${item.url}.`);
         // eslint-disable-next-line no-console
         console.error(tex);
 
@@ -266,11 +264,11 @@ export const UpdateCachedItem = async (
     let reqObj = await GetRequestObject(item);
     if (!reqObj) {
         item.status.cacheStatus = "prepared";
-        if (item.fullUrl && item.fullUrl !== "/") {
+        if (item.url && item.url !== "/") {
             reqObj = BuildRequestObject(item);
             CleanRequestObject(item, reqObj);
         } else {
-            // Without a fullUrl we cannot retrieve this item
+            // Without a full url we cannot retrieve this item
             // from either the cache or the network
             return false;
         }

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -28,12 +28,12 @@ class ManifestError extends Error {
     }
 }
 
-export const ManifestAPIURL = "/manifest/v1";
+export const ManifestBackendPath = "/manifest/v1";
 export const ManifestCacheKey = "bero-manifest";
 
 export class Manifest extends PublishableItem implements StorableItem {
-    get api_url(): string {
-        return ManifestAPIURL;
+    get backendPath(): string {
+        return ManifestBackendPath;
     }
 
     /** The cache in which the manifest is stored */

--- a/src/ts/Implementations/Manifest.ts
+++ b/src/ts/Implementations/Manifest.ts
@@ -17,7 +17,6 @@ import TeachingTopic from "./Specific/TeachingTopic";
 import TeachingActivity from "./Specific/TeachingActivity";
 
 // See ts/Typings for the type definitions for these imports
-import { BACKEND_BASE_URL, ROUTES_FOR_REGISTRATION } from "js/urls";
 import { storeManifest, getManifestFromStore } from "ReduxImpl/Interface";
 
 const logger = new Logger("Manifest");
@@ -29,12 +28,11 @@ class ManifestError extends Error {
     }
 }
 
-export const ManifestAPIURL = `${BACKEND_BASE_URL}/manifest/v1`;
-export const ManifestCacheKey = "canoe-manifest";
+export const ManifestAPIURL = "/manifest/v1";
+export const ManifestCacheKey = "bero-manifest";
 
 export class Manifest extends PublishableItem implements StorableItem {
-    /** The api url of the manifest */
-    get url(): string {
+    get api_url(): string {
         return ManifestAPIURL;
     }
 
@@ -96,10 +94,6 @@ export class Manifest extends PublishableItem implements StorableItem {
 
     get version(): number {
         return this.storedData?.version || -1;
-    }
-
-    get fullUrl(): string {
-        return ROUTES_FOR_REGISTRATION.manifest;
     }
 
     get contentType(): string {

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -17,7 +17,6 @@ import {
 } from "ReduxImpl/Interface";
 import { persistCompletion } from "js/actions/Completion";
 import { persistFeedback } from "js/UserActions";
-import { BACKEND_BASE_URL } from "js/urls";
 
 const logger = new Logger("Page");
 
@@ -48,9 +47,8 @@ export class Page extends PublishableItem implements StorableItem {
         this.#parent = parent;
     }
 
-    /** The api url of this page */
-    get url(): string {
-        return `${BACKEND_BASE_URL}${this.manifestData?.api_url}`;
+    get api_url(): string {
+        return this.manifestData?.api_url || "";
     }
 
     /** The cache in which the page is stored */

--- a/src/ts/Implementations/Page.ts
+++ b/src/ts/Implementations/Page.ts
@@ -47,7 +47,7 @@ export class Page extends PublishableItem implements StorableItem {
         this.#parent = parent;
     }
 
-    get api_url(): string {
+    get backendPath(): string {
         return this.manifestData?.api_url || "";
     }
 

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -15,8 +15,8 @@ const logger = new Logger("ContentItem");
  * @remarks The item can be queried for cache status and added and removed from the cache
  */
 export abstract class PublishableItem {
-    /** The api_url of this item as recorded in the manifest */
-    abstract get api_url(): string;
+    /** The backendPath of this item as recorded in the manifest (in some form or other) */
+    abstract get backendPath(): string;
     /** The name of the cache used to store this item */
     abstract get cacheKey(): string;
     /** Request options dict used to retrieve this item */
@@ -24,7 +24,7 @@ export abstract class PublishableItem {
 
     /** The (full) url to retrieve this item from */
     get url(): string {
-        return this.api_url ? `${BACKEND_BASE_URL}${this.api_url}` : "";
+        return this.backendPath ? `${BACKEND_BASE_URL}${this.backendPath}` : "";
     }
 
     /** The options used to query the caches for this item */

--- a/src/ts/Implementations/PublishableItem.ts
+++ b/src/ts/Implementations/PublishableItem.ts
@@ -1,5 +1,8 @@
 import Logger from "../Logger";
 
+// See ts/Typings for the type definitions for these imports
+import { BACKEND_BASE_URL } from "js/urls";
+
 export enum UpdatePolicy {
     Default = "default",
     ForceUpdate = "forceUpdate",
@@ -9,17 +12,22 @@ export enum UpdatePolicy {
 const logger = new Logger("ContentItem");
 
 /** A network backed content item that can be stored and retrieved from a named cache
- * The item can be queeried for cache status and added and remove from the cache
+ * @remarks The item can be queried for cache status and added and removed from the cache
  */
 export abstract class PublishableItem {
-    /** The url to retrieve this item from */
-    abstract get url(): string;
+    /** The api_url of this item as recorded in the manifest */
+    abstract get api_url(): string;
     /** The name of the cache used to store this item */
     abstract get cacheKey(): string;
     /** Request options dict used to retrieve this item */
     abstract get requestOptions(): RequestInit;
     /** Brief descriptive string for logs */
     abstract get str(): string;
+
+    /** The (full) url to retrieve this item from */
+    get url(): string {
+        return this.api_url ? `${BACKEND_BASE_URL}${this.api_url}` : "";
+    }
 
     /** The options used to query the caches for this item */
     get cacheOptions(): MultiCacheQueryOptions {

--- a/src/ts/Types/PageTypes.ts
+++ b/src/ts/Types/PageTypes.ts
@@ -3,14 +3,20 @@ import { TItemCommon, TPublishableItem } from "./PublishableItemTypes";
 import { TAssetEntry } from "./AssetTypes";
 
 export type TPageData = {
+    title: string;
+    type: TPageType | string;
     loc_hash: string;
     storage_container: string;
-    assets: Array<TAssetEntry>;
+    version: number;
+    slug: string;
+    api_url: string;
     language: string;
     children: Array<string>;
     depth: number;
-    type: TPageType | string;
-    title: string;
+    card_image: string;
+    tags: Array<string>;
+    revision_id: BigInteger;
+    assets: Array<TAssetEntry>;
 } & TItemCommon;
 
 export type TPage = TPageData & TPublishableItem;


### PR DESCRIPTION
# Description

Legacy code used `fullUrl` and `api_url` members to identify where to get resources from, and under what name to save them in the cache.

Over time `fullUrl` was mostly changed  to just `url`.  Also the structure of the `Page` related information within the `Manifest` was standardised, including the usage of `api_url`.

This :pr: :

* Cleans up the `PageType` type to provide better typing support, obviously this includes the `api_url` member.  With the consistency in the manifest this reliably works, and ensures that TypeScript can provide significantly better 'compile' time type support.
* The `PublishableItem` abstract base class is slightly refactored to make much better use of `api_url` and define a better `url`.  The refactoring was to pivot the code from `url` to `api_url`, which is a better fit for its usage in cache interactions.
* `Asset` has special handling for `api_url` so this was refactored to match.
* `Manifest` had its `fullUrl` member removed (it's not used).  Because api_url and cacheKey are interrelated the `ManifestCacheKey` was also updated at this time from `canoe-manifest` to `bero-manifest`.
* `CacheItem` had all of its references to `fullUrl` replaced with `url`.  However it should be noted that most of this code is already deprecated and will likely disappear very soon.