### PR TITLE
solution for card heights

### DIFF
--- a/src/index.hbs
+++ b/src/index.hbs
@@ -54,6 +54,7 @@
         }
 
         body {
+            height: 100%;
             margin: 0;
         }
 

--- a/src/riot/Components/LessonFrame.riot.html
+++ b/src/riot/Components/LessonFrame.riot.html
@@ -26,7 +26,7 @@
             <span class="cross gray"></span>
         </a>
     </TopMenu>
-    <div class="frame-background {userAgent()}">
+    <div class="frame-background">
         <div class="{!props.noCardStyle ? 'card-frame' : 'no-card'}">
             <div class="card-content {props.extrastyleclasses}">
                 <slot />
@@ -37,6 +37,7 @@
             </template>
         </div>
     </div>
+    <slot name="bottom-buttons" />
 
     <script>
         import TopMenu from "RiotTags/Components/TopMenu.riot.html";
@@ -52,15 +53,6 @@
                     ? this.props.close()
                     : (window.location.hash = `#${this.props.linkTo}`);
             },
-
-            userAgent() {
-                const { browser } = getPlatform();
-                // iphone 8+ and earlier models have a max height of 736;
-                if (window.innerHeight <= 736) {
-                    return `${browser.name.toLowerCase()} hasHomeButton`
-                }
-                return browser.name.toLowerCase();
-            }
         };
     </script>
 </LessonFrame>

--- a/src/riot/Lesson/CourseExam.riot.html
+++ b/src/riot/Lesson/CourseExam.riot.html
@@ -1,4 +1,4 @@
-<CourseExam>
+<CourseExam class="fill-screen">
     <template if="{ stage === 'code' || !isNaN(cardNumber) }">
         <template if="{ stage === 'code' && course.examType !== 'prelearning'}">
             <HonorCode></HonorCode>
@@ -14,32 +14,32 @@
             <Test
                 card-number="{ cardNumber }"
             ></Test>
+            <div slot="bottom-buttons" if="{ !isNaN(cardNumber) }" class="bottom-buttons">
+                <div>
+                    <a if="{ cardNumber > 1 }" class="has-circle" onclick="{previousExamCard}">
+                        <span class="arrow"></span>
+                    </a>
+                </div>
+                <div>
+                    <button
+                        if="{ cardNumber < examCards.length }"
+                        class="btn-primary"
+                        onclick="{nextExamCard}"
+                        disabled="{ !hasAnswer() }"
+                    >
+                        { TRANSLATIONS.next() }
+                    </button>
+                    <button
+                        if="{ cardNumber === examCards.length }"
+                        class="btn-primary"
+                        onclick="{nextExamCard}"
+                        disabled="{ !hasAnswer() }"
+                    >
+                        { TRANSLATIONS.submit() }
+                    </button>
+                </div>
+            </div>
         </LessonFrame>
-        <div if="{ !isNaN(cardNumber) }" class="bottom-buttons">
-            <div>
-                <a if="{ cardNumber > 1 }" class="has-circle" onclick="{previousExamCard}">
-                    <span class="arrow"></span>
-                </a>
-            </div>
-            <div>
-                <button
-                    if="{ cardNumber < examCards.length }"
-                    class="btn-primary"
-                    onclick="{nextExamCard}"
-                    disabled="{ !hasAnswer() }"
-                >
-                    { TRANSLATIONS.next() }
-                </button>
-                <button
-                    if="{ cardNumber === examCards.length }"
-                    class="btn-primary"
-                    onclick="{nextExamCard}"
-                    disabled="{ !hasAnswer() }"
-                >
-                    { TRANSLATIONS.submit() }
-                </button>
-            </div>
-        </div>
     </template>
 
     <ExamResults

--- a/src/riot/Lesson/ExamReview.riot.html
+++ b/src/riot/Lesson/ExamReview.riot.html
@@ -1,4 +1,4 @@
-<ExamReview>
+<ExamReview class="fill-screen">
     <div if="{ stage === 'summary'}" class="exam-summary">
         <span class="exam-review"></span>
         <h3>{ TRANSLATIONS.review() }</h3>
@@ -35,23 +35,23 @@
                 </div>
                 <raw html="{ incorrectAnswers[stage - 1].revision_note }"></raw>
             </div>
+            <div slot="bottom-buttons" if="{ !isNaN(stage) }" class="bottom-buttons">
+                <div>
+                    <a if="{ stage > 1 }" class="has-circle" onclick="{previousReviewCard}">
+                        <span class="arrow"></span>
+                    </a>
+                </div>
+                <div>
+                    <button
+                        if="{ stage <= incorrectAnswers.length }"
+                        class="btn-primary"
+                        onclick="{nextReviewCard}"
+                    >
+                        { TRANSLATIONS.next() }
+                    </button>
+                </div>
+            </div>
         </LessonFrame>
-        <div if="{ !isNaN(stage) }" class="bottom-buttons">
-            <div>
-                <a if="{ stage > 1 }" class="has-circle" onclick="{previousReviewCard}">
-                    <span class="arrow"></span>
-                </a>
-            </div>
-            <div>
-                <button
-                    if="{ stage <= incorrectAnswers.length }"
-                    class="btn-primary"
-                    onclick="{nextReviewCard}"
-                >
-                    { TRANSLATIONS.next() }
-                </button>
-            </div>
-        </div>
     </template>
 
     <div if="{ stage === 'complete'}" class="exam-summary">

--- a/src/riot/Lesson/LessonContent.riot.html
+++ b/src/riot/Lesson/LessonContent.riot.html
@@ -1,4 +1,4 @@
-<LessonContent>
+<LessonContent class="fill-screen">
     <LessonFrame
         if="{ card && cardNumber <= cards.length }"
         extraStyleClasses="{ isAQuestion() ? 'test' : 'content' }"
@@ -28,37 +28,39 @@
             if="{ isAQuestion() }"
             toggleModal="{ toggleTestModal }">
         </Test>
+        <div
+            slot="bottom-buttons"
+            if="{ card && cardNumber <= cards.length }"
+            class="bottom-buttons"
+        >
+            <div>
+                <a
+                    if="{ cardNumber > 1 }"
+                    class="has-circle"
+                    onclick="{ goBack }"
+                >
+                    <span class="arrow"></span>
+                </a>
+            </div>
+            <div>
+                <button
+                    class="btn-primary"
+                    onclick="{ nextCard }"
+                    if="{ cardNumber < cards.length && !isAQuestion() }"
+                >
+                    { TRANSLATIONS.next() }
+                </button>
+                <button
+                    class="btn-primary"
+                    onclick="{ completeLesson }"
+                    if="{ cardNumber === cards.length && !isAQuestion() }"
+                >
+                    { TRANSLATIONS.finish() }
+                </button>
+            </div>
+        </div>
     </LessonFrame>
-    <div
-        if="{ card && cardNumber <= cards.length }"
-        class="bottom-buttons"
-    >
-        <div>
-            <a
-                if="{ cardNumber > 1 }"
-                class="has-circle"
-                onclick="{ goBack }"
-            >
-                <span class="arrow"></span>
-            </a>
-        </div>
-        <div>
-            <button
-                class="btn-primary"
-                onclick="{ nextCard }"
-                if="{ cardNumber < cards.length && !isAQuestion() }"
-            >
-                { TRANSLATIONS.next() }
-            </button>
-            <button
-                class="btn-primary"
-                onclick="{ completeLesson }"
-                if="{ cardNumber === cards.length && !isAQuestion() }"
-            >
-                { TRANSLATIONS.finish() }
-            </button>
-        </div>
-    </div>
+
     <TestPopupModal
         if="{ state.showModal }"
         toggleModal="{ toggleTestModal }"

--- a/src/riot/Lesson/LessonFeedback.riot.html
+++ b/src/riot/Lesson/LessonFeedback.riot.html
@@ -1,4 +1,4 @@
-<LessonFeedback>
+<LessonFeedback class="fill-screen">
     <LessonFrame linkTo="{ props.linkTo }">
         <template if="{!state.submittedFeedback}">
             <div class="message-container">
@@ -57,27 +57,30 @@
                 <p>{ TRANSLATIONS.feedback_sent() }</p>
             </div>
         </template>
+        <div slot="bottom-buttons" class="bottom-buttons">
+            <template if="{!state.submittedFeedback}">
+                <button class="btn-secondary" onclick="{clickedNoThanks}">
+                    { TRANSLATIONS.no() }
+                </button>
+                <button
+                    class="btn-primary"
+                    onclick="{clickedSubmit}"
+                    disabled="{!state.activeSelection}"
+                >
+                    { TRANSLATIONS.submit() }
+                </button>
+            </template>
+            <template if="{state.submittedFeedback}">
+                <button
+                    class="btn-primary thank-you-container"
+                    onclick="{clickedContinue}"
+                >
+                    { TRANSLATIONS.continue() }
+                </button>
+            </template>
+        </div>
     </LessonFrame>
-    <div if="{!state.submittedFeedback}" class="bottom-buttons">
-        <button class="btn-secondary" onclick="{clickedNoThanks}">
-            { TRANSLATIONS.no() }
-        </button>
-        <button
-            class="btn-primary"
-            onclick="{clickedSubmit}"
-            disabled="{!state.activeSelection}"
-        >
-            { TRANSLATIONS.submit() }
-        </button>
-    </div>
-    <div if="{state.submittedFeedback}" class="bottom-buttons">
-        <button
-            class="btn-primary thank-you-container"
-            onclick="{clickedContinue}"
-        >
-            { TRANSLATIONS.continue() }
-        </button>
-    </div>
+
     <script>
         import LessonFrame from "RiotTags/Components/LessonFrame.riot.html";
         import { getRoute } from "ReduxImpl/Interface";

--- a/src/riot/Teaching/ActivityFeedback.riot.html
+++ b/src/riot/Teaching/ActivityFeedback.riot.html
@@ -56,27 +56,31 @@
                 <p>{ TRANSLATIONS.feedback_sent() }</p>
             </div>
         </template>
+        <div slot="bottom-buttons" class="bottom-buttons">
+            <template if="{!state.madeFeedbackDecision}">
+                <button class="btn-secondary" onclick="{clickedNoThanks}">
+                    { TRANSLATIONS.no() }
+                </button>
+                <button
+                    class="btn-primary"
+                    onclick="{clickedSubmit}"
+                    disabled="{!state.activeSelection}"
+                >
+                    { TRANSLATIONS.submit() }
+                </button>
+            </template>
+            <template if="{state.madeFeedbackDecision}">
+                <button
+                    class="btn-primary thank-you-container"
+                    onclick="{clickedContinue}"
+                >
+                    { TRANSLATIONS.continue() }
+                </button>
+
+            </template>
+        </div>
     </LessonFrame>
-    <div if="{!state.madeFeedbackDecision}" class="bottom-buttons">
-        <button class="btn-secondary" onclick="{clickedNoThanks}">
-            { TRANSLATIONS.no() }
-        </button>
-        <button
-            class="btn-primary"
-            onclick="{clickedSubmit}"
-            disabled="{!state.activeSelection}"
-        >
-            { TRANSLATIONS.submit() }
-        </button>
-    </div>
-    <div if="{state.madeFeedbackDecision}" class="bottom-buttons">
-        <button
-            class="btn-primary thank-you-container"
-            onclick="{clickedContinue}"
-        >
-            { TRANSLATIONS.continue() }
-        </button>
-    </div>
+
     <script>
         import LessonFrame from "RiotTags/Components/LessonFrame.riot.html";
         import { getRoute } from "ReduxImpl/Interface";

--- a/src/riot/WagtailPages/LessonPage.riot.html
+++ b/src/riot/WagtailPages/LessonPage.riot.html
@@ -1,4 +1,4 @@
-<LessonPage>
+<LessonPage class="fill-screen">
     <LessonFrame
         if="{lesson.ready}"
         linkTo="{lesson.course.loc_hash}"
@@ -17,12 +17,12 @@
             <p>{lesson.shortDescription}</p>
             <p>{lesson.longDescription}</p>
         </div>
+        <div slot="bottom-buttons" if="{lesson.ready}" class="bottom-buttons">
+            <button class="btn-primary" onclick="{startLesson}">
+                { TRANSLATIONS.start() }
+            </button>
+        </div>
     </LessonFrame>
-    <div if="{lesson.ready}" class="bottom-buttons">
-        <button class="btn-primary" onclick="{startLesson}">
-            { TRANSLATIONS.start() }
-        </button>
-    </div>
 
     <script>
         import LessonFrame from "RiotTags/Components/LessonFrame.riot.html";

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -31,6 +31,10 @@ LessonPage {
 }
 
 LessonFrame {
+    height: 100%;
+    display: grid;
+    grid-template-rows: $top-menu-height 1fr 70px;
+
     .without-swoop {
         justify-content: center;
 
@@ -57,28 +61,11 @@ LessonFrame {
         }
     }
 
-    // the 25px adds some room for the stacked cards below, the 50px is
-    // for the buttons
-    $base-card-height: calc(100vh - #{$top-menu-height} - 25px - 50px);
-
     .frame-background {
-        height: $base-card-height;
         display: flex;
         flex-flow: row nowrap;
         align-items: stretch;
-
-        &.safari {
-            height: calc(#{$base-card-height} - 100px);
-
-            &.hasHomeButton {
-                height: calc(#{$base-card-height} - 85px);
-            }
-        }
-
-        &.chrome,
-        &.firefox {
-            height: calc(#{$base-card-height} - 60px);
-        }
+        overflow: auto;
     }
 
     .card-frame {

--- a/src/scss/canoe.scss
+++ b/src/scss/canoe.scss
@@ -50,3 +50,7 @@ div.content-wrapper {
     max-width: $tablet;
     margin: auto;
 }
+
+.fill-screen {
+    height: 100%;
+}


### PR DESCRIPTION
Following from https://github.com/catalpainternational/hamahon/issues/258
Reference PRs from Alessandro: 
https://github.com/catalpainternational/refer/pull/100/files#
https://github.com/catalpainternational/refer/pull/118/files

Today I learned about [named slots](https://riot.js.org/api/#named-slots) which made this a lot easier than all previous attempts at a solution. Enabled me to shuffle the button elements around and use the power of grid to fill the screen up.

<img src="https://user-images.githubusercontent.com/12974326/121981639-69186f00-cdd1-11eb-9f85-3d3a2b5b8c51.jpeg" width="250">
<img src="https://user-images.githubusercontent.com/12974326/121981653-6c135f80-cdd1-11eb-8349-93f0be792963.png" width="250">

