### PR TITLE
Use singletons and statics to avoid `globalThis` (and flinging an AppelflapConnect object around everywhere)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -34,7 +34,7 @@ initialiseIdentity()  // Am I logged in
         // perform independent actions that require login in parallel
         return Promise.all([
             initialiseUserActions(), // read actiion from api and idb
-            initialiseCertChain(),   // initialise the appelflap sharing cert
+            initialiseCertChain(),   // initialise the appelflap package publishing cert
         ]);
     }).then(() => {
         initialiseRouting();         // react to the navigation hash

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,6 @@ import { EMPTY_SLATE_BOOT_KEY } from "ts/Constants";
 
 let currentServiceWorkerState = getServiceWorkerState();
 
-// Create the global beroHost and certChain objects
-var beroHost = null;
-var certChain = null;
 // Initialise the beroHost object
 InitialiseBeroHost();
 

--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -47,7 +47,6 @@
 
     <script>
         import { AppDataStatus } from "ts/AppDataStatus";
-        import { AppelflapConnect } from "ts/Appelflap/AppelflapConnect";
         import { CacheUtilities } from "ts/Appelflap/CacheUtilities";
         import { CachePublish } from "ts/Appelflap/CachePublish";
 
@@ -56,7 +55,6 @@
                 statusListings: [],
                 publications: "",
                 appDataStatus: new AppDataStatus(),
-                appelflapConnect: null,
             },
 
             TRANSLATIONS: {
@@ -70,17 +68,13 @@
 
             async appelflapStatus() {
                 this.update({ appelflapMeta: "Getting" });
-                
-                this.state.appelflapConnect = new AppelflapConnect();
 
                 /* Not yet implemented
-                const cacheUtilities = new CacheUtilities(this.state.appelflapConnect);
-                const cacheStatus = await cacheUtilities.status();
+                const cacheStatus = await CacheUtilities.status();
                 this.update({ cacheStatus: JSON.stringify(cacheStatus) });
                 */
 
-                const cachePublish = new CachePublish(this.state.appelflapConnect);
-                const publications = await cachePublish.publications();
+                const publications = await CachePublish.publications();
                 this.update(({ publications: JSON.stringify(publications) }));
 
                 // Get the Item Status Listing
@@ -89,14 +83,13 @@
             },
 
             async syncMe() {
-                const cacheUtilities = new CacheUtilities(this.state.appelflapConnect);
-                await cacheUtilities.unlock();
+                await CacheUtilities.unlock();
 
                 // Identify what needs to be subscribed to, and what needs to be published
                 const appDataStatus = this.state.appDataStatus;
                 const syncStatus = await appDataStatus.SyncAll();
 
-                await cacheUtilities.lock();
+                await CacheUtilities.lock();
 
                 // window.alert(`Published: ${JSON.stringify(syncStatus)}`);
             },

--- a/src/ts/AppDataStatus.ts
+++ b/src/ts/AppDataStatus.ts
@@ -17,15 +17,7 @@ import {
 import { Manifest } from "./Implementations/Manifest";
 import { Page } from "./Implementations/Page";
 
-import { AppelflapConnect } from "./Appelflap/AppelflapConnect";
-
-// See ts/Typings for the type definitions for these imports
-import { getPageData as getPageDataFromStore } from "ReduxImpl/Interface";
-
-type AfcFunction = (
-    item: TPublishableItem,
-    appelflapConnect: AppelflapConnect
-) => Promise<TAppelflapResult>;
+type AfcFunction = (item: TPublishableItem) => Promise<TAppelflapResult>;
 
 /** An overview of the status for all cached data used by the app */
 export class AppDataStatus {
@@ -61,8 +53,6 @@ export class AppDataStatus {
         let isValid = false;
         let isAvailableOffline = false;
         let isPublishable = false;
-
-        const pageData = getPageDataFromStore(pageId);
 
         if (inCache) {
             const page = new Page(this.manifest, pageId);
@@ -130,7 +120,6 @@ export class AppDataStatus {
         filter: (item: TItemListing) => boolean,
         action: AfcFunction
     ) {
-        const appelflapConnect = new AppelflapConnect();
         const performable = this.itemListings.filter(filter);
 
         const performed: TPublishResult = {};
@@ -140,10 +129,7 @@ export class AppDataStatus {
                 try {
                     const publishableManifest =
                         await this.ManifestToPublishableItem(this.manifest);
-                    const result = await action(
-                        publishableManifest,
-                        appelflapConnect
-                    );
+                    const result = await action(publishableManifest);
                     performed[this.manifest.cacheKey] = {
                         result: result,
                         reason: result,
@@ -166,8 +152,7 @@ export class AppDataStatus {
                         const publishablePage =
                             await this.PageToPublishableItem(page);
                         const result =
-                            (await action(publishablePage, appelflapConnect)) ||
-                            "not relevant";
+                            (await action(publishablePage)) || "not relevant";
                         performed[item.cacheKey] = {
                             result: result,
                             reason: result,
@@ -200,8 +185,7 @@ export class AppDataStatus {
 
     /** Get all current subscriptions */
     async GetSubscriptions(): Promise<TSubscriptions> {
-        const appelflapConnect = new AppelflapConnect();
-        const subscriptions = await getSubscriptions(appelflapConnect);
+        const subscriptions = await getSubscriptions();
         if (typeof subscriptions === "string") {
             return { origins: {} };
         }
@@ -210,11 +194,7 @@ export class AppDataStatus {
 
     /** Set all current subscriptions */
     async SetSubscriptions(): Promise<TSubscriptions> {
-        const appelflapConnect = new AppelflapConnect();
-        const subscriptions = await setSubscriptions(
-            this.itemListings,
-            appelflapConnect
-        );
+        const subscriptions = await setSubscriptions(this.itemListings);
         if (typeof subscriptions === "string") {
             return { origins: {} };
         }

--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -34,7 +34,7 @@ export class AppelflapConnect {
         if (!AppelflapConnect.instance) {
             const gt = globalThis as Record<string, any>;
             gt["AFC_MOCKMODE"] = gt["AFC_MOCKMODE"] || false;
-    
+
             if (!gt["AFC_MOCKMODE"]) {
                 AppelflapConnect.instance = inAppelflap()
                     ? new AppelflapConnect()

--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -14,10 +14,42 @@ import { AF_CERTCHAIN_LENGTH_HEADER, AF_LOCALHOSTURI, APPELFLAPCOMMANDS, Appelfl
 /* eslint-enable prettier/prettier */
 
 import Logger from "../Logger";
+import { inAppelflap } from "../PlatformDetection";
 
 const logger = new Logger("AppelflapConnect");
 
 export class AppelflapConnect {
+    //#region Implement as Singleton
+    static instance: AppelflapConnect | undefined;
+
+    private constructor() {
+        logger.log("Singleton created");
+    }
+
+    /**
+     * Gets the single instance of AppelflapConnect
+     * or undefined if we're not inAppelflap
+     */
+    public static get Instance(): AppelflapConnect | undefined {
+        if (!AppelflapConnect.instance) {
+            const gt = globalThis as Record<string, any>;
+            gt["AFC_MOCKMODE"] = gt["AFC_MOCKMODE"] || false;
+    
+            if (!gt["AFC_MOCKMODE"]) {
+                AppelflapConnect.instance = inAppelflap()
+                    ? new AppelflapConnect()
+                    : undefined;
+            } else {
+                // Return a 'mock' of AppelflapConnect
+                // to be used only in testing
+                AppelflapConnect.instance = new AppelflapConnect();
+            }
+        }
+
+        return AppelflapConnect.instance;
+    }
+    //#endregion
+
     /** Get the Authorisation Header details that Appelflap requires
      * @remarks See: https://github.com/catalpainternational/appelflap/blob/7a4072f8b914748563333238bb1a49ea527480bd/docs/API/determining-endpoint.md for more info
      * @returns The auth header as `Basic btoaEncodedStuff` or 'None' if the credentials are not available

--- a/src/ts/Appelflap/CachePublish.ts
+++ b/src/ts/Appelflap/CachePublish.ts
@@ -2,24 +2,25 @@ import { AppelflapConnect } from "./AppelflapConnect";
 import { TPublications, TPublication } from "../Types/CacheTypes";
 
 export class CachePublish {
-    #afc: AppelflapConnect;
-
-    constructor(afc: AppelflapConnect) {
-        this.#afc = afc;
+    /** Get a list of published items from Appelflap */
+    static async publications(): Promise<TPublications> {
+        if (AppelflapConnect.Instance) {
+            return await AppelflapConnect.Instance.getPublications();
+        }
+        return {};
     }
 
-    /** Get a list of published items from Appelflap */
-    publications = async (): Promise<TPublications> => {
-        return await this.#afc.getPublications();
-    };
-
     /** Instructs Appelflap to 'publish' a single publication */
-    publish = async (publication: TPublication): Promise<void> => {
-        await this.#afc.publish(publication);
-    };
+    static async publish(publication: TPublication): Promise<void> {
+        if (AppelflapConnect.Instance) {
+            await AppelflapConnect.Instance.publish(publication);
+        }
+    }
 
     /** Instructs Appelflap to cease publishing a single publication */
-    unpublish = async (publication: TPublication): Promise<void> => {
-        await this.#afc.unpublish(publication);
-    };
+    static async unpublish(publication: TPublication): Promise<void> {
+        if (AppelflapConnect.Instance) {
+            await AppelflapConnect.Instance.unpublish(publication);
+        }
+    }
 }

--- a/src/ts/Appelflap/CacheSubscribe.ts
+++ b/src/ts/Appelflap/CacheSubscribe.ts
@@ -1,24 +1,22 @@
 import { TSubscriptions } from "../Types/CacheTypes";
-
 import { AppelflapConnect } from "./AppelflapConnect";
 
 export class CacheSubscribe {
-    #subscriptions: TSubscriptions = { origins: {} };
-    #afc: AppelflapConnect;
-
-    constructor(afc: AppelflapConnect) {
-        this.#afc = afc;
+    static async getSubscriptions(): Promise<TSubscriptions> {
+        if (AppelflapConnect.Instance) {
+            return await AppelflapConnect.Instance.getSubscriptions();
+        }
+        return { origins: {} };
     }
 
-    async getSubscriptions(): Promise<TSubscriptions> {
-        this.#subscriptions = await this.#afc.getSubscriptions();
-        return this.#subscriptions;
-    }
-
-    async setSubscriptions(
+    static async setSubscriptions(
         subscriptions: TSubscriptions
     ): Promise<TSubscriptions> {
-        this.#subscriptions = await this.#afc.setSubscriptions(subscriptions);
-        return this.#subscriptions;
+        if (AppelflapConnect.Instance) {
+            return await AppelflapConnect.Instance.setSubscriptions(
+                subscriptions
+            );
+        }
+        return { origins: {} };
     }
 }

--- a/src/ts/Appelflap/CacheUtilities.ts
+++ b/src/ts/Appelflap/CacheUtilities.ts
@@ -1,30 +1,32 @@
 import { AppelflapConnect } from "./AppelflapConnect";
 
 export class CacheUtilities {
-    #afc: AppelflapConnect;
-
-    constructor(afc: AppelflapConnect) {
-        this.#afc = afc;
+    /** Get the status of the cache from Appelflap */
+    static async status(): Promise<any> {
+        if (AppelflapConnect.Instance) {
+            return JSON.parse(await AppelflapConnect.Instance.getCacheStatus());
+        }
+        return {};
     }
 
-    /** Get the status of the cache from Appelflap */
-    status = async (): Promise<any> => {
-        const statusDescription = await this.#afc.getCacheStatus();
-        return JSON.parse(statusDescription);
-    };
-
     /** Instruct Appelflap to reboot Bero */
-    reboot = async (): Promise<void> => {
-        await this.#afc.doReboot();
-    };
+    static async reboot(): Promise<void> {
+        if (AppelflapConnect.Instance) {
+            await AppelflapConnect.Instance.doReboot();
+        }
+    }
 
     /** Instruct Appelflap to consider the cache as 'locked' */
-    lock = async (): Promise<void> => {
-        await this.#afc.lock();
-    };
+    static async lock(): Promise<void> {
+        if (AppelflapConnect.Instance) {
+            await AppelflapConnect.Instance.lock();
+        }
+    }
 
     /** Instruct Appelflap to consider the cache as 'unlocked' */
-    unlock = async (): Promise<void> => {
-        await this.#afc.unlock();
-    };
+    static async unlock(): Promise<void> {
+        if (AppelflapConnect.Instance) {
+            await AppelflapConnect.Instance.unlock();
+        }
+    }
 }

--- a/src/ts/Implementations/ItemActions.ts
+++ b/src/ts/Implementations/ItemActions.ts
@@ -23,17 +23,14 @@ const CacheTarget = (item: TPublishableItem): TPublication => {
  * - reject("failed") on error (404 or 500)
  */
 export async function publishItem(
-    item: TPublishableItem,
-    appelflapConnect: AppelflapConnect
+    item: TPublishableItem
 ): Promise<TAppelflapResult> {
-    if (!item || !item.isPublishable || !appelflapConnect) {
+    if (!item || !item.isPublishable || !AppelflapConnect.Instance) {
         return Promise.resolve("not relevant");
     }
 
-    const cachePublish = new CachePublish(appelflapConnect);
-
     try {
-        await cachePublish.publish(CacheTarget(item));
+        await CachePublish.publish(CacheTarget(item));
         return Promise.resolve("succeeded");
     } catch (error) {
         return Promise.reject("failed");
@@ -47,17 +44,14 @@ export async function publishItem(
  * - reject("failed") on error (404 or 500)
  */
 export async function unpublishItem(
-    item: TPublishableItem,
-    appelflapConnect: AppelflapConnect
+    item: TPublishableItem
 ): Promise<TAppelflapResult> {
-    if (!item || item.isPublishable || !appelflapConnect) {
+    if (!item || item.isPublishable || !AppelflapConnect.Instance) {
         return Promise.resolve("not relevant");
     }
 
-    const cachePublish = new CachePublish(appelflapConnect);
-
     try {
-        await cachePublish.unpublish(CacheTarget(item));
+        await CachePublish.unpublish(CacheTarget(item));
         return Promise.resolve("succeeded");
     } catch (error) {
         return Promise.reject("failed");
@@ -70,17 +64,13 @@ export async function unpublishItem(
  * - resolve("not relevant") if appelflap connect wasn't provided,
  * - reject("failed") on error (404 or 500)
  */
-export async function getSubscriptions(
-    appelflapConnect: AppelflapConnect
-): Promise<TSubscriptions | string> {
-    if (!appelflapConnect) {
+export async function getSubscriptions(): Promise<TSubscriptions | string> {
+    if (!AppelflapConnect.Instance) {
         return Promise.resolve("not relevant");
     }
 
-    const cacheSubscribe = new CacheSubscribe(appelflapConnect);
-
     try {
-        const subscriptions = await cacheSubscribe.getSubscriptions();
+        const subscriptions = await CacheSubscribe.getSubscriptions();
         return Promise.resolve(subscriptions);
     } catch (error) {
         return Promise.reject("failed");
@@ -94,19 +84,16 @@ export async function getSubscriptions(
  * - reject("failed") on error (404 or 500)
  */
 export async function setSubscriptions(
-    items: TItemListing[],
-    appelflapConnect: AppelflapConnect
+    items: TItemListing[]
 ): Promise<TSubscriptions | string> {
     if (
         !items ||
         !items.length ||
         !items.some((item) => !item.isPublishable) ||
-        !appelflapConnect
+        !AppelflapConnect.Instance
     ) {
         return Promise.resolve("not relevant");
     }
-
-    const cacheSubscribe = new CacheSubscribe(appelflapConnect);
 
     const subscriptions: TSubscriptions = {
         origins: {},
@@ -125,7 +112,7 @@ export async function setSubscriptions(
     });
 
     try {
-        const result = await cacheSubscribe.setSubscriptions(subscriptions);
+        const result = await CacheSubscribe.setSubscriptions(subscriptions);
         return Promise.resolve(result);
     } catch (error) {
         return Promise.reject("failed");

--- a/src/ts/tests/AppelflapConnect.test.ts
+++ b/src/ts/tests/AppelflapConnect.test.ts
@@ -23,7 +23,9 @@ import { AF_LOCALHOSTURI, AF_EIKEL_META_API, AF_CACHE_API, AF_ACTION_API, AF_INS
 test.before((t: any) => {
     t.context["testPort"] = 9090;
     global["navigator"] = buildFakeNavigator(t.context.testPort);
-    t.context["afc"] = new AppelflapConnect();
+    const gt = globalThis as Record<string, any>;
+    gt["AFC_MOCKMODE"] = true;
+    t.context["afc"] = AppelflapConnect.Instance;
 });
 
 test.beforeEach((t: any) => {
@@ -221,7 +223,7 @@ test("Cache: publish", async (t: any) => {
     const webOrigin = "some-web-origin";
     const cacheName = "some-cache-name";
     const version = 10;
-    const testUri = `${AF_LOCALHOSTURI}:${t.context.testPort}/${AF_CACHE_API}/${AF_PUBLICATIONS}/${webOrigin}/${cacheName}`;
+    const testUri = `${AF_LOCALHOSTURI}:${t.context.testPort}/${AF_CACHE_API}/${AF_PUBLICATIONS}/${webOrigin}/${cacheName}/${version}`;
     const publication: TPublication = {
         webOrigin: webOrigin,
         cacheName: cacheName,
@@ -260,7 +262,7 @@ test("Cache: unpublish", async (t: any) => {
     const webOrigin = "some-web-origin";
     const cacheName = "some-cache-name";
     const version = 10;
-    const testUri = `${AF_LOCALHOSTURI}:${t.context.testPort}/${AF_CACHE_API}/${AF_PUBLICATIONS}/${webOrigin}/${cacheName}`;
+    const testUri = `${AF_LOCALHOSTURI}:${t.context.testPort}/${AF_CACHE_API}/${AF_PUBLICATIONS}/${webOrigin}/${cacheName}/${version}`;
     const publication: TPublication = {
         webOrigin: webOrigin,
         cacheName: cacheName,


### PR DESCRIPTION
# Description

# precursor to #751 

Prior to fixing up the handling of the package publishing certificate (certChain) when the user logs in and logs out, it seemed prudent to clean up some old and rather verbose code.

Converted to Singletons (and removed as globals accessed via `globalThis`):
* AppelflapConnect
* BeroHost
* CertChain

Converted to `static` classes (all methods are static):
* CachePublish
* CacheSubscribe
* CacheUtilties

Which meant that all of the following could be simplified, especially as there is no longer any need to pass around an `AppelflapConnect` object or set up globals:
* index.js
* Sync.riot.html
* AppDataStatus
* StartUp
* ItemActions

And also the AppelflapConnect.test file was fixed up - try `yarn test` it works.