### PR TITLE
Preload the lesson assets when prepared (routed to)

### DIFF
--- a/src/ts/Implementations/Specific/Lesson.ts
+++ b/src/ts/Implementations/Specific/Lesson.ts
@@ -51,6 +51,11 @@ export default class Lesson extends Page {
     get threads(): Array<Thread> {
         return this.storedData?.discussion;
     }
+    /** extend the prepare call to make the lesson available offline pre-loading assets used */
+    async prepare(): Promise<void> {
+        super.prepare();
+        this.makeAvailableOffline();
+    }
 }
 
 class Thread {


### PR DESCRIPTION
fixes #593 

Preloads the lesson assets so unless you have a really bad connection you will not see images waiting to switch on card navigation.

Test by emptying your cache ( or just the lesson cache in question ) then navigating to the lesson.