### PR TITLE
Allow configuration of csrf cookie name

### DIFF
--- a/canoe-environment-default.js
+++ b/canoe-environment-default.js
@@ -13,4 +13,5 @@ module.exports = {
         },
     },
     GUEST_USERNAME: "Guest",
+    CSRF_COOKIE_NAME: 'csrftoken',
 };

--- a/src/js/AuthenticationUtilities.js
+++ b/src/js/AuthenticationUtilities.js
@@ -1,4 +1,4 @@
-import { BACKEND_BASE_URL } from "js/urls";
+import { BACKEND_BASE_URL, CSRF_COOKIE_NAME } from "js/urls";
 import { unsubscribeFromNotifications } from "js/Notifications";
 import { setAuthenticated, setUnauthenticated, getUser } from "ReduxImpl/Interface";
 import Cookies from "js-cookie";
@@ -14,7 +14,7 @@ export const login = async (usernameAndPassword) => {
         credentials: 'include',
         body: formData,
         headers: {
-            "X-CSRFToken": Cookies.get("csrftoken"),
+            "X-CSRFToken": Cookies.get(CSRF_COOKIE_NAME),
         },
     })
     .then((response) => {
@@ -29,7 +29,7 @@ export const logout = () => {
         method: "DELETE",
         credentials: 'include',
         headers: {
-            "X-CSRFToken": Cookies.get("csrftoken"),
+            "X-CSRFToken": Cookies.get(CSRF_COOKIE_NAME),
         },
     }).catch((err) => {
         // delete the Canoe=Offline-Session cookie

--- a/src/js/Notifications.js
+++ b/src/js/Notifications.js
@@ -1,4 +1,4 @@
-import { BACKEND_BASE_URL } from "js/urls";
+import { BACKEND_BASE_URL, CSRF_COOKIE_NAME } from "js/urls";
 import { getBrowser } from "ts/PlatformDetection";
 import { urlBase64ToUint8Array } from "js/DjangoPushNotifications";
 import { alertIfRequestWasMadeOffline } from "js/Errors";
@@ -46,7 +46,7 @@ const postNotificationSubscription = async (subscriptionData) => {
         credentials: "include",
         headers: {
             "Content-Type": "application/json",
-            "X-CSRFToken": Cookies.get("csrftoken"),
+            "X-CSRFToken": Cookies.get(CSRF_COOKIE_NAME),
         },
         method: "POST",
         body: JSON.stringify(subscriptionData),

--- a/src/js/actions/actions_api.js
+++ b/src/js/actions/actions_api.js
@@ -1,5 +1,5 @@
 import Cookies from "js-cookie";
-import { BACKEND_BASE_URL } from "js/urls";
+import { BACKEND_BASE_URL, CSRF_COOKIE_NAME } from "js/urls";
 
 const ACTIONS_ENDPOINT_URL = `${BACKEND_BASE_URL}/progress/actions`;
 
@@ -46,6 +46,6 @@ export function getActions() {
 function getHeaders() {
     return {
         "Content-Type": "application/json",
-        "X-CSRFToken": Cookies.get("csrftoken"),
+        "X-CSRFToken": Cookies.get(CSRF_COOKIE_NAME),
     };
 }

--- a/src/js/urls.js
+++ b/src/js/urls.js
@@ -1,4 +1,5 @@
 export const BACKEND_BASE_URL = process.env.API_BASE_URL;
+export const CSRF_COOKIE_NAME = process.env.CSRF_COOKIE_NAME;
 
 export const ROUTES_FOR_REGISTRATION = {
     media: `${BACKEND_BASE_URL}/media/media(_transcodes)?/.+`,

--- a/src/ts/Discussion.ts
+++ b/src/ts/Discussion.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import Cookies from "js-cookie";
 
-import { BACKEND_BASE_URL } from "js/urls";
+import { BACKEND_BASE_URL, CSRF_COOKIE_NAME } from "js/urls";
 
 const DISCUSSION_BASE_URL = `${BACKEND_BASE_URL}/discussion`;
 
@@ -108,7 +108,7 @@ export class Discussion {
             credentials: "include",
             headers: {
                 "content-type": "application/json",
-                "X-CSRFToken": Cookies.get("csrftoken"),
+                "X-CSRFToken": Cookies.get(CSRF_COOKIE_NAME),
             },
             body: JSON.stringify(body),
         } as RequestInit;

--- a/src/ts/Typings/urls.d.ts
+++ b/src/ts/Typings/urls.d.ts
@@ -3,6 +3,7 @@
 /** Note that the module name here MUST match how it's used in the .ts files */
 declare module "js/urls" {
     export const BACKEND_BASE_URL: string;
+    export const CSRF_COOKIE_NAME: string;
     export const MEDIA_PATH: string;
 
     export const ROUTES_FOR_REGISTRATION: Record<string, string>;


### PR DESCRIPTION
untested

This is needed becasue Hamahon is running in production with cookie domains of `.hamahon.tl` and in beta on `.beta.hamahon.tl` and we are getting clashes on the django cookies.
Beta requests include the production cookies, and django chooses the wrong one to use.

renaming the cookies server side is simple with django settings CSRF_COOKIE_NAME and SESSION_COOKIE_NAME, but canoe needs to know what name the csrf cookie is saved as to read the value to include in post requests csrf headers