### PR TITLE
Match the useragent string from Appelflap configs

### DIFF
--- a/src/ts/PlatformDetection.ts
+++ b/src/ts/PlatformDetection.ts
@@ -33,7 +33,7 @@ export function getBrowser(): TBrowser {
         M.splice(1, 1, tem[1]);
     }
 
-    if (navigator.userAgent.startsWith("io.catalpa.canoe.")) {
+    if (navigator.userAgent.startsWith("io.catalpa.bero.")) {
         M = ["Firefox", 1000];
     }
 
@@ -44,7 +44,7 @@ export function getBrowser(): TBrowser {
 }
 
 export function inAppelflap(): boolean {
-    return navigator.userAgent.startsWith("io.catalpa.canoe.");
+    return navigator.userAgent.startsWith("io.catalpa.bero.");
 }
 
 function inPWAMode(): boolean {


### PR DESCRIPTION
# Description

Appelflap has had most (if not all) of its references to `canoe` changed to `bero`, which includes what is usually set up in the `build.gradle` `productFlavors` part of an app's Appelflap config for its `applicationId`, which now all start with `io.catalpa.bero.`

This value shows up in the PWA as the `userAgent` string from the global `navigator` object and is the key test to determine whether the PWA is running `inAppelflap`.

This updates the test in the PWA to match what Appelflap does in its configs.