### PR TITLE
minor prep work before adding an isPublished stat

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -12,23 +12,23 @@
                 <li
                     each="{(statusListing, index) in state.statusListings}">
                     <div class="sync-header">
-                        <h5>ID:{statusListing.id} {statusListing.type}:{statusListing.title} <small>({statusListing.version})</small> </h5>
+                        <h5><small>{statusListing.type}:</small> { statusListing.title }</h5>
                     </div>
-
-                    <div if="{statusListing.backendPath === statusListing.cacheKey}" class="sync-body">
+                    <!-- <div class="sync-body"><small>version: {statusListing.version}</small></div> -->
+                    <!-- <div if="{statusListing.backendPath === statusListing.cacheKey}" class="sync-body">
                         <span><small>Store Path/Cache Key:</small> { statusListing.backendPath }</span>
-                    </div>
-                    <div if="{statusListing.backendPath != statusListing.cacheKey}" class="sync-body">
+                    </div> -->
+                    <!-- <div if="{statusListing.backendPath != statusListing.cacheKey}" class="sync-body">
                         <span><small>Store Path:</small> { statusListing.backendPath }</span>
-                    </div>
-                    <div if="{statusListing.backendPath != statusListing.cacheKey}" class="sync-body">
+                    </div> -->
+                    <!-- <div if="{statusListing.backendPath != statusListing.cacheKey}" class="sync-body">
                         <span><small>Cache Key:</small> { statusListing.cacheKey }</span>
-                    </div>
+                    </div> -->
 
                     <div class="sync-body">
-                        <span>Validity:{ statusListing.isValid },  </span>
-                        <span>Availablity:{ statusListing.isAvailableOffline },  </span>
-                        <span>Publishable:{ statusListing.isPublishable }, </span>
+                        <span><small>Validity:</small> { statusListing.isValid },  </span>
+                        <span><small>Availablity:</small> { statusListing.isAvailableOffline },  </span>
+                        <span><small>Publishable:</small> { statusListing.isPublishable }, </span>
                     </div>
 
                     <!-- <div class="sync-footer">

--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -26,8 +26,6 @@
                     </div> -->
 
                     <div class="sync-body">
-                        <span><small>Validity:</small> { statusListing.isValid },  </span>
-                        <span><small>Availablity:</small> { statusListing.isAvailableOffline },  </span>
                         <span><small>Publishable:</small> { statusListing.isPublishable }, </span>
                     </div>
 

--- a/src/ts/AppDataStatus.ts
+++ b/src/ts/AppDataStatus.ts
@@ -81,6 +81,7 @@ export class AppDataStatus {
         const pageIds = Object.keys(this.manifest.pages);
         const cacheKeys = await CacheKeys();
 
+        const pageListings: TItemListing[] = [];
         for (let ix = 0; ix < pageIds.length; ix++) {
             const pageId = pageIds[ix];
             const manifestPage = this.manifest.pages[pageId];
@@ -90,8 +91,35 @@ export class AppDataStatus {
                 manifestPage,
                 inCache
             );
-            this.itemListings.push(pageListing);
+            pageListings.push(pageListing);
         }
+
+        // Add the page listings in order of published, publishable, available, valid, none of the above
+        this.itemListings.push(
+            ...pageListings.filter((pageListing) => pageListing.isPublishable)
+        );
+        this.itemListings.push(
+            ...pageListings.filter(
+                (pageListing) =>
+                    !pageListing.isPublishable && pageListing.isAvailableOffline
+            )
+        );
+        this.itemListings.push(
+            ...pageListings.filter(
+                (pageListing) =>
+                    !pageListing.isPublishable &&
+                    !pageListing.isAvailableOffline &&
+                    pageListing.isValid
+            )
+        );
+        this.itemListings.push(
+            ...pageListings.filter(
+                (pageListing) =>
+                    !pageListing.isPublishable &&
+                    !pageListing.isAvailableOffline &&
+                    !pageListing.isValid
+            )
+        );
     }
 
     private async ManifestToPublishableItem(

--- a/src/ts/Types/PublishableItemTypes.ts
+++ b/src/ts/Types/PublishableItemTypes.ts
@@ -11,13 +11,13 @@ export type TItemStatus = {
     /** Is this manifest, page or asset item valid? */
     isValid: boolean;
 
-    /** Is this manifest, page or asset item available offline?
+    /** Is this manifest or page available offline?
      * @remarks This is used to indicate to the UI that a given item is ready for rendering
-     * @returns true if all items referenced by this manifest, page or asset item are available offline as well
+     * @returns true if all items referenced by this manifest or page are available offline as well
      */
     isAvailableOffline: boolean;
 
-    /** Is this manifest, page or asset item complete (in itself) and ready for distribution?
+    /** Is this manifest or page complete (in itself) and ready for distribution?
      * @remarks This is used to tell Appelflap that this individual item can be shared to other devices
      * @returns true is this item itself is complete - all descendant pages and assets are in the cache
      */


### PR DESCRIPTION
# Description

Minor cleanup work before focusing on adding an `isPublished` status to the list of items (that may or may not be) in the cache.
* Remove superfluous data from the sync page item listing - reduce the visual noise
* Sort the listing - not critical but really helps with debugging
* Fix up some old comments - again not critical, but helps avoid confusion when I add the `isPublished` status