### PR TITLE
Get peer Id from Appelflap

### DIFF
--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -15,6 +15,7 @@ import { AF_CERTCHAIN_LENGTH_HEADER, AF_LOCALHOSTURI, APPELFLAPCOMMANDS } from "
 
 import Logger from "../Logger";
 import { inAppelflap } from "../PlatformDetection";
+import { TPeerProperties } from "../Types/PeerTypes";
 
 const logger = new Logger("AppelflapConnect");
 
@@ -26,6 +27,7 @@ export class AppelflapConnect {
         password: string;
         port: number;
     };
+    #peerProperties?: TPeerProperties;
 
     private constructor() {
         logger.log("Singleton created");
@@ -164,29 +166,21 @@ export class AppelflapConnect {
         }
     };
 
+    public getPeerProperties = async (): Promise<TPeerProperties> => {
+        if (!this.#peerProperties) {
+            const { commandPath } = APPELFLAPCOMMANDS.getPeerProperties;
+            logger.info(`Getting peer properties`);
+
+            const response = await fetch(commandPath);
+            this.#peerProperties = await response.json();
+            logger.info("Got peer properties");
+        }
+
+        return this.#peerProperties!;
+    };
+
     public getLargeObjectIndexStatus = async (): Promise<any> => {
         const { commandPath } = APPELFLAPCOMMANDS.getLargeObjectIndexStatus;
-        return await this.performCommand(commandPath);
-    };
-
-    public lock = async (): Promise<string> => {
-        const { commandPath, method } = APPELFLAPCOMMANDS.setLock;
-        logger.info(`'Locking' Bero`);
-        return await this.performCommand(commandPath, { method }, "text");
-    };
-
-    public unlock = async (): Promise<string> => {
-        const { commandPath, method } = APPELFLAPCOMMANDS.releaseLock;
-        logger.info(`'Unlocking' Bero`);
-        return await this.performCommand(commandPath, { method }, "text");
-    };
-
-    /**
-     * Get the status of the cache from Appelflap
-     * @deprecated No longer available from Appelflap, returns 404
-     */
-    public getCacheStatus = async (): Promise<any> => {
-        const { commandPath } = APPELFLAPCOMMANDS.getCacheStatus;
         return await this.performCommand(commandPath);
     };
     //#endregion
@@ -211,6 +205,29 @@ export class AppelflapConnect {
         const { commandPath, method } =
             APPELFLAPCOMMANDS.doLaunchStorageManager;
         return await this.performCommand(commandPath, { method }, "text");
+    };
+    //#endregion
+
+    //#region Cache Administration
+    public lock = async (): Promise<string> => {
+        const { commandPath, method } = APPELFLAPCOMMANDS.setLock;
+        logger.info(`'Locking' Bero`);
+        return await this.performCommand(commandPath, { method }, "text");
+    };
+
+    public unlock = async (): Promise<string> => {
+        const { commandPath, method } = APPELFLAPCOMMANDS.releaseLock;
+        logger.info(`'Unlocking' Bero`);
+        return await this.performCommand(commandPath, { method }, "text");
+    };
+
+    /**
+     * Get the status of the cache from Appelflap
+     * @deprecated No longer available from Appelflap, returns 404
+     */
+    public getCacheStatus = async (): Promise<any> => {
+        const { commandPath } = APPELFLAPCOMMANDS.getCacheStatus;
+        return await this.performCommand(commandPath);
     };
     //#endregion
 

--- a/src/ts/Appelflap/AppelflapRouting.ts
+++ b/src/ts/Appelflap/AppelflapRouting.ts
@@ -8,7 +8,8 @@ export const AF_LOCALHOSTURI = "http://localhost";
 export const AF_API_PREFIX = "appelflap";
 
 export const AF_ENDPOINT = `moz-extension://${AF_API_PREFIX}`;
-export const AF_PROPERTIES = "serverinfo.json";
+export const AF_SERVER_PROPERTIES = "serverinfo.json";
+export const AF_PEER_PROPERTIES = "peerid.json";
 
 export const AF_EIKEL_API = `${AF_API_PREFIX}/eikel`;
 export const AF_EIKEL_META_API = `${AF_API_PREFIX}/eikel-meta`;
@@ -31,7 +32,11 @@ export const AF_CERTCHAIN_LENGTH_HEADER = "X-Appelflap-Chain-Length";
 /** These are all of the commands provided by Appelflap across its API surface */
 export const APPELFLAPCOMMANDS = {
     getEndpointProperties: {
-        commandPath: `${AF_ENDPOINT}/${AF_PROPERTIES}`,
+        commandPath: `${AF_ENDPOINT}/${AF_SERVER_PROPERTIES}`,
+        method: "GET",
+    },
+    getPeerProperties: {
+        commandPath: `${AF_ENDPOINT}/${AF_PEER_PROPERTIES}`,
         method: "GET",
     },
     getLargeObjectIndexStatus: {

--- a/src/ts/Appelflap/AppelflapUtilities.ts
+++ b/src/ts/Appelflap/AppelflapUtilities.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { TPeerProperties } from "../Types/PeerTypes";
+import { AppelflapConnect } from "./AppelflapConnect";
+
+export class AppelflapUtilities {
+    /** Get the 'peer' properties from Appelflap */
+    static async peerProperties(): Promise<TPeerProperties | undefined> {
+        if (AppelflapConnect.getInstance()) {
+            return await AppelflapConnect.getInstance()!.getPeerProperties();
+        }
+    }
+
+    /**
+     * Get the status of the cache from Appelflap
+     * @deprecated No longer available from Appelflap, returns 404
+     */
+    static async status(): Promise<any> {
+        if (AppelflapConnect.getInstance()) {
+            return JSON.parse(
+                await AppelflapConnect.getInstance()!.getCacheStatus()
+            );
+        }
+        return {};
+    }
+
+    /** Instruct Appelflap to hard reboot Bero */
+    static async rebootHard(): Promise<void> {
+        if (AppelflapConnect.getInstance()) {
+            await AppelflapConnect.getInstance()!.doRebootHard();
+        }
+    }
+
+    /** Instruct Appelflap to soft reboot Bero */
+    static async rebootSoft(): Promise<void> {
+        if (AppelflapConnect.getInstance()) {
+            await AppelflapConnect.getInstance()!.doRebootSoft();
+        }
+    }
+
+    /** Instruct Appelflap to launch the Android WiFi picker */
+    static async launchWiFiPicker(): Promise<void> {
+        if (AppelflapConnect.getInstance()) {
+            await AppelflapConnect.getInstance()!.doLaunchWiFiPicker();
+        }
+    }
+
+    /** Instruct Appelflap to launch the Android storage manager */
+    static async launchStorageManager(): Promise<void> {
+        if (AppelflapConnect.getInstance()) {
+            await AppelflapConnect.getInstance()!.doLaunchStorageManager();
+        }
+    }
+}

--- a/src/ts/Appelflap/CacheUtilities.ts
+++ b/src/ts/Appelflap/CacheUtilities.ts
@@ -2,47 +2,6 @@
 import { AppelflapConnect } from "./AppelflapConnect";
 
 export class CacheUtilities {
-    /**
-     * Get the status of the cache from Appelflap
-     * @deprecated No longer available from Appelflap, returns 404
-     */
-    static async status(): Promise<any> {
-        if (AppelflapConnect.getInstance()) {
-            return JSON.parse(
-                await AppelflapConnect.getInstance()!.getCacheStatus()
-            );
-        }
-        return {};
-    }
-
-    /** Instruct Appelflap to hard reboot Bero */
-    static async rebootHard(): Promise<void> {
-        if (AppelflapConnect.getInstance()) {
-            await AppelflapConnect.getInstance()!.doRebootHard();
-        }
-    }
-
-    /** Instruct Appelflap to soft reboot Bero */
-    static async rebootSoft(): Promise<void> {
-        if (AppelflapConnect.getInstance()) {
-            await AppelflapConnect.getInstance()!.doRebootSoft();
-        }
-    }
-
-    /** Instruct Appelflap to launch the Android WiFi picker */
-    static async launchWiFiPicker(): Promise<void> {
-        if (AppelflapConnect.getInstance()) {
-            await AppelflapConnect.getInstance()!.doLaunchWiFiPicker();
-        }
-    }
-
-    /** Instruct Appelflap to launch the Android storage manager */
-    static async launchStorageManager(): Promise<void> {
-        if (AppelflapConnect.getInstance()) {
-            await AppelflapConnect.getInstance()!.doLaunchStorageManager();
-        }
-    }
-
     /** Instruct Appelflap to consider the cache as 'locked' */
     static async lock(): Promise<void> {
         if (AppelflapConnect.getInstance()) {

--- a/src/ts/Types/PeerTypes.ts
+++ b/src/ts/Types/PeerTypes.ts
@@ -1,0 +1,8 @@
+/** A set of values that identify this user, as a peer for sharing */
+export type TPeerProperties = {
+    ID: number;
+    /** A 4 character representation of the @see ID, that has been derived from the @see palette */
+    friendly_ID: string;
+    /** This is the 'palette' of characters from which the @see friendly_ID has been formed */
+    palette: string;
+};

--- a/src/ts/tests/AppelflapConnect.test.ts
+++ b/src/ts/tests/AppelflapConnect.test.ts
@@ -17,7 +17,7 @@ import {
 /* eslint-disable prettier/prettier */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: For when the unit tests cannot find the declaration file
-import { AF_LOCALHOSTURI, AF_ENDPOINT, AF_PROPERTIES, AF_EIKEL_META_API, AF_CACHE_API, AF_ACTION_API, AF_INS_LOCK, AF_PUBLICATIONS, AF_SUBSCRIPTIONS, AF_STATUS, AF_REBOOT, AF_CERTCHAIN, AF_CERTCHAIN_LENGTH_HEADER } from "ts/Appelflap/AppelflapRouting";
+import { AF_LOCALHOSTURI, AF_ENDPOINT, AF_SERVER_PROPERTIES, AF_EIKEL_META_API, AF_CACHE_API, AF_ACTION_API, AF_INS_LOCK, AF_PUBLICATIONS, AF_SUBSCRIPTIONS, AF_STATUS, AF_REBOOT_SOFT, AF_CERTCHAIN, AF_CERTCHAIN_LENGTH_HEADER } from "ts/Appelflap/AppelflapRouting";
 // The above import statement MUST all appear on the one line for the @ts-ignore to work
 /* eslint-enable prettier/prettier */
 
@@ -34,7 +34,7 @@ test.before((t: any) => {
         password: "b",
         port: t.context["testPort"],
     };
-    fetchMock.mock(`${AF_ENDPOINT}/${AF_PROPERTIES}`, endpointProps);
+    fetchMock.mock(`${AF_ENDPOINT}/${AF_SERVER_PROPERTIES}`, endpointProps);
 });
 
 test.beforeEach(async (t: any) => {
@@ -170,7 +170,7 @@ test("Cache: canoe reboot soft", async (t: any) => {
     const successResponse = t.context.successResponse as Response;
     const authFailureResponse = t.context.authFailureResponse as Response;
 
-    const testUri = `${AF_LOCALHOSTURI}:${t.context.testPort}/${AF_ACTION_API}/${AF_REBOOT}`;
+    const testUri = `${AF_LOCALHOSTURI}:${t.context.testPort}/${AF_ACTION_API}/${AF_REBOOT_SOFT}`;
 
     fetchMock.post(testUri, successResponse);
     const successResult = await afc.doRebootSoft();


### PR DESCRIPTION
# Description

Via the mozilla extension used by Appelflap we now have access to a Peer ID for a user.

This can be wired into the Sync page as that user's 'peer' ID

The format returned looks like this:
``` json
{
  "ID": 3657874,
  "friendly_ID": "qZdP",
  "palette": "23456789abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
}
```
For which this :pr: provides a TypeScript type of `TPeerProperties` and a get property accessor on the `AppelflapUtilities` module called `peerProperties`.

This :pr: also does some refactoring now that we have some additional Appelflap specific functions, that have nothing to do with the caching. So that we have a more representative structure of actual functionality.