### PR TITLE
Remove support for DELETE publication within the front end

### DIFF
--- a/src/ts/AppDataStatus.ts
+++ b/src/ts/AppDataStatus.ts
@@ -197,7 +197,10 @@ export class AppDataStatus {
         return performed;
     }
 
-    /** Publish everything currently flagged as isPublishable */
+    /** Publish everything currently flagged as isPublishable
+     * @remarks Note that there is no `UnpublishAll`.
+     * Unpublishing (deleting) something published is handled by Appelflap itself.
+     */
     async PublishAll(): Promise<TPublishResult> {
         return this.PerformAll((listing) => listing.isPublishable, publishItem);
     }

--- a/src/ts/AppDataStatus.ts
+++ b/src/ts/AppDataStatus.ts
@@ -12,7 +12,6 @@ import {
     getSubscriptions,
     publishItem,
     setSubscriptions,
-    unpublishItem,
 } from "./Implementations/ItemActions";
 import { Manifest } from "./Implementations/Manifest";
 import { Page } from "./Implementations/Page";
@@ -203,14 +202,6 @@ export class AppDataStatus {
         return this.PerformAll((listing) => listing.isPublishable, publishItem);
     }
 
-    /** Unpublish everything currently not flagged as isPublishable */
-    async UnpublishAll(): Promise<TPublishResult> {
-        return this.PerformAll(
-            (listing) => !listing.isPublishable,
-            unpublishItem
-        );
-    }
-
     /** Get all current subscriptions */
     async GetSubscriptions(): Promise<TSubscriptions> {
         const subscriptions = await getSubscriptions();
@@ -235,12 +226,10 @@ export class AppDataStatus {
         this.itemListings.forEach((listing) => {
             syncAllStatus[listing.cacheKey] = {
                 published: "failed",
-                unpublished: "failed",
             };
         });
 
         const published = await this.PublishAll();
-        const unpublished = await this.UnpublishAll();
         let subscriptions = await this.GetSubscriptions();
         let origins = Object.keys(subscriptions.types.CACHE?.groups || {});
         let subscribed =
@@ -278,9 +267,6 @@ export class AppDataStatus {
 
         Object.entries(published).forEach((pub) => {
             syncAllStatus[pub[0]].published = pub[1].result;
-        });
-        Object.entries(unpublished).forEach((pub) => {
-            syncAllStatus[pub[0]].unpublished = pub[1].result;
         });
 
         return syncAllStatus;

--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -257,15 +257,6 @@ export class AppelflapConnect {
 
         return await this.performCommand(requestPath, commandInit, "text");
     };
-
-    public unpublish = async (publication: TPublication): Promise<string> => {
-        const { commandPath, method } = APPELFLAPCOMMANDS.deletePublication;
-        const requestPath = `${commandPath}/${this.publicationPath(
-            publication
-        )}`;
-
-        return await this.performCommand(requestPath, { method }, "text");
-    };
     //#endregion
 
     //#region Subscriptions

--- a/src/ts/Appelflap/AppelflapRouting.ts
+++ b/src/ts/Appelflap/AppelflapRouting.ts
@@ -80,10 +80,11 @@ export const APPELFLAPCOMMANDS = {
         commandPath: `${AF_CACHE_API}/${AF_PUBLICATIONS}`,
         method: "PUT",
     },
-    deletePublication: {
-        commandPath: `${AF_CACHE_API}/${AF_PUBLICATIONS}`,
-        method: "DELETE",
-    },
+    /** @deprecated Do not use, this is performed by Appelflap garbage collection now */
+    // deletePublication: {
+    //     commandPath: `${AF_CACHE_API}/${AF_PUBLICATIONS}`,
+    //     method: "DELETE",
+    // },
     getSubscriptions: {
         commandPath: `${AF_CACHE_API}/${AF_SUBSCRIPTIONS}`,
         method: "GET",

--- a/src/ts/Appelflap/CachePublish.ts
+++ b/src/ts/Appelflap/CachePublish.ts
@@ -18,11 +18,4 @@ export class CachePublish {
             await AppelflapConnect.getInstance()!.publish(publication);
         }
     }
-
-    /** Instructs Appelflap to cease publishing a single publication */
-    static async unpublish(publication: TPublication): Promise<void> {
-        if (AppelflapConnect.getInstance()) {
-            await AppelflapConnect.getInstance()!.unpublish(publication);
-        }
-    }
 }

--- a/src/ts/Appelflap/CachePublish.ts
+++ b/src/ts/Appelflap/CachePublish.ts
@@ -12,7 +12,11 @@ export class CachePublish {
         return { bundles: [] };
     }
 
-    /** Instructs Appelflap to 'publish' a single publication */
+    /**
+     * Instructs Appelflap to 'publish' a single publication
+     * @remarks Note that there is no `unpublish`.
+     * Unpublishing (deleting) something published is handled by Appelflap itself.
+     */
     static async publish(publication: TPublication): Promise<void> {
         if (AppelflapConnect.getInstance()) {
             await AppelflapConnect.getInstance()!.publish(publication);

--- a/src/ts/Implementations/ItemActions.ts
+++ b/src/ts/Implementations/ItemActions.ts
@@ -58,27 +58,6 @@ export async function publishItem(
     }
 }
 
-/** Tells Appelflap to unpublish this item's cache
- * @returns
- * - resolve("succeeded") on success (200),
- * - resolve("not relevant") if isPublishable is true or appelflap connect wasn't provided,
- * - reject("failed") on error (404 or 500)
- */
-export async function unpublishItem(
-    item: TPublishableItem
-): Promise<TAppelflapResult> {
-    if (!item || item.isPublishable || !AppelflapConnect.getInstance()) {
-        return Promise.resolve("not relevant");
-    }
-
-    try {
-        await CachePublish.unpublish(CacheTarget(item));
-        return Promise.resolve("succeeded");
-    } catch (error) {
-        return Promise.reject("failed");
-    }
-}
-
 /** Tells Appelflap to retrieve all current subscriptions
  * @returns
  * - resolve("succeeded") on success (200),

--- a/src/ts/Implementations/ItemActions.ts
+++ b/src/ts/Implementations/ItemActions.ts
@@ -42,6 +42,8 @@ export async function getPublications(): Promise<TBundles | string> {
  * - resolve("succeeded") on success (200),
  * - resolve("not relevant") if isPublishable is false or appelflap connect wasn't provided,
  * - reject("failed") on error (404 or 500)
+ * @remarks Note that there is no `unpublishItem`.
+ * Unpublishing (deleting) something published is handled by Appelflap itself.
  */
 export async function publishItem(
     item: TPublishableItem

--- a/src/ts/Types/CanoeEnums.ts
+++ b/src/ts/Types/CanoeEnums.ts
@@ -5,9 +5,6 @@
  * or whether it is relinquishing that lock and can be restarted */
 export type TLock = "lock" | "unlock";
 
-/** Whether a certain 'package' is (or should be) published or is (or should be) unpublished */
-export type TPublish = "publish" | "unpublish";
-
 /** Whether a certain 'package' is (or should be) subscribed to or is (or should be) unsubscribed from */
 export type TSubscribe = "subscribe" | "unsubscribe";
 

--- a/src/ts/Types/SyncTypes.ts
+++ b/src/ts/Types/SyncTypes.ts
@@ -4,7 +4,6 @@ export type TSyncData = Record<
     string,
     {
         published: TAppelflapResult;
-        unpublished: TAppelflapResult;
     }
 >;
 

--- a/src/ts/tests/AppelflapConnect.test.ts
+++ b/src/ts/tests/AppelflapConnect.test.ts
@@ -234,45 +234,6 @@ test.skip("Cache: publish", async (t: any) => {
     fetchMock.reset();
 });
 
-test.skip("Cache: unpublish", async (t: any) => {
-    const afc = t.context.afc as AppelflapConnect;
-    const successResponse = t.context.successResponse as Response;
-    const authFailureResponse = t.context.authFailureResponse as Response;
-    const notFoundResponse = t.context.notFoundResponse as Response;
-    const conflictResponse = t.context.conflictResponse as Response;
-
-    const bundleType = "CACHE";
-    const webOrigin = "some-web-origin";
-    const cacheName = "some-cache-name";
-    const version = 10;
-    const testUri = `${AF_LOCALHOSTURI}:${t.context.testPort}/${AF_CACHE_API}/${AF_PUBLICATIONS}/${bundleType}/${webOrigin}/${cacheName}/${version}`;
-    const publication: TPublication = {
-        bundleType: bundleType,
-        webOrigin: webOrigin,
-        cacheName: cacheName,
-        version: version,
-    };
-
-    // When doing throwsAsync tests, expect 2 assertions returned for each test
-    // And do the 'ok' test last to ensure that all tests are awaited
-    t.plan(7);
-    [authFailureResponse, notFoundResponse, conflictResponse].forEach(
-        async (response) => {
-            fetchMock.delete(testUri, response, { overwriteRoutes: true });
-            const failureResult = await t.throwsAsync(
-                afc.unpublish(publication)
-            );
-            t.is(failureResult.message, response.statusText);
-        }
-    );
-
-    fetchMock.delete(testUri, successResponse, { overwriteRoutes: true });
-    const successResult = await afc.unpublish(publication);
-    t.is(successResult, "ok");
-
-    fetchMock.reset();
-});
-
 test("Cache: getSubscriptions", async (t: any) => {
     const afc = t.context.afc as AppelflapConnect;
     const authFailureResponse = t.context.authFailureResponse as Response;


### PR DESCRIPTION
# Description

As per a comment by @boerwastaken (https://github.com/catalpainternational/canoe/pull/782#discussion_r662945410) - this removes the support for `DELETE` to the `publications` endpoint provided by Appelflap.

Instead cleaning up things is left to Appelflap to do.