### PR TITLE
Minor fixes to Sync page

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -142,7 +142,7 @@
                 statusListings: [],
                 appDataStatus: new AppDataStatus(),
                 ssid: "",
-                peerId: "unknown",
+                peerId: { friendly_ID: "unknown" },
                 peers: [],
                 // could be "outdated" or "current" - determined from the Manifest
                 contentStatus: "outdated",
@@ -202,7 +202,7 @@
             },
 
             get yourSyncAvatar() {
-                return this.mapAvatar(this.state.peerId);
+                return this.mapAvatar(this.state.peerId.friendly_ID);
             },
 
             get syncStatusText() {
@@ -211,7 +211,7 @@
 
             get mappedPeers() {
                 const peers = this.state.peers;
-                return peers.map((it) => this.mapAvatar(it));
+                return peers.map((peer) => this.mapAvatar(peer.friendly_ID));
             },
 
             get usedSpacePercentage() {
@@ -241,18 +241,24 @@
 
             async onMounted() {
                 // Get Peer info from Appelflap
-                this.update({peerId: (await AppelflapUtilities.peerProperties()) || "unknown"});
-                this.update({peers: (await AppelflapUtilities.infoPeers()) || []});
+                this.update({
+                    peerId: (await AppelflapUtilities.peerProperties()) || { friendly_ID: "unknown" },
+                    peers: await AppelflapUtilities.infoPeers(),
+                });
 
                 // Get WiFi info from Appelflap
+                // Note the spelling mistake in `ipadress` and `ipadress_raw`
                 const { ssid, ipadress, ipadress_raw, strength } =
                     (await AppelflapUtilities.infoWiFi())
                     || { ssid: "", ipadress: "", ipadress_raw: 0, strength: 0 };
-                this.update({ssid: ssid});
+                this.update({ ssid: ssid });
 
                 // Get the disk utilisation info from Appelflap
                 const { disksize, diskfree } = await AppelflapUtilities.infoStorage() || { disksize: 0, diskfree: 0 };
-                this.update({usedSpacePercentage: !!disksize ? (diskfree / disksize) * 100 : 0 });
+                const usedPct = !!disksize
+                    ? ((disksize - diskfree) / disksize) * 100
+                    : 0;
+                this.update({ usedSpacePercentage: usedPct });
 
                 const subscriptionsUpdated = await this.refreshSubscriptions();
                 await this.publishAll();

--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -221,7 +221,17 @@ export class AppelflapConnect {
 
     public infoPeers = async (): Promise<TPeers> => {
         const { commandPath, method } = APPELFLAPCOMMANDS.infoPeers;
-        return await this.performCommand(commandPath, { method });
+        // Note that the infoPeers command doesn't return the field names with the same case
+        // so some manipulation is required
+        const peers: TPeers = (
+            (await this.performCommand(commandPath, { method })) || []
+        ).map((peer: Record<string, any>) => {
+            return {
+                ID: peer.id,
+                friendly_ID: peer.friendly_ID,
+            } as TPeerProperties;
+        });
+        return peers;
     };
 
     public infoStorage = async (): Promise<TInfoStorage> => {

--- a/src/ts/Appelflap/AppelflapUtilities.ts
+++ b/src/ts/Appelflap/AppelflapUtilities.ts
@@ -23,10 +23,11 @@ export class AppelflapUtilities {
     }
 
     /** Get the properties for the current 'peers' of this user */
-    static async infoPeers(): Promise<TPeers | undefined> {
+    static async infoPeers(): Promise<TPeers> {
         if (AppelflapConnect.getInstance()) {
             return await AppelflapConnect.getInstance()!.infoPeers();
         }
+        return [];
     }
 
     static async infoStorage(): Promise<TInfoStorage | undefined> {


### PR DESCRIPTION
# Description

Now that the 'other' sync page features have been used for the first time, there were a few bugs to fix:

* 'Avatars' for this user and their peers referencing the wrong thing to generate the 'avatar' - it was using the object itself, rather than the `friendly_ID` field
* The `bonjour-peers` API endpoint returns the same fields as the `peerid.json` API endpoint - but with a different case. So a mapping was added to make what `bonjour-peers` returns the same as `peerid.json`
* The used storage percentage calculation was wrong (it was showing the free space percentage)