### PR TITLE
Basic wiring up of `do inject-cache`

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -240,40 +240,21 @@
             },
 
             async onMounted() {
-                // Get Peer info from Appelflap
-                this.update({
-                    peerId: (await AppelflapUtilities.peerProperties()) || { friendly_ID: "unknown" },
-                    peers: await AppelflapUtilities.infoPeers(),
-                });
-
-                // Get WiFi info from Appelflap
-                // Note the spelling mistake in `ipadress` and `ipadress_raw`
-                const { ssid, ipadress, ipadress_raw, strength } =
-                    (await AppelflapUtilities.infoWiFi())
-                    || { ssid: "", ipadress: "", ipadress_raw: 0, strength: 0 };
-                this.update({ ssid: ssid });
-
-                // Get the disk utilisation info from Appelflap
-                const { disksize, diskfree } = await AppelflapUtilities.infoStorage() || { disksize: 0, diskfree: 0 };
-                const usedPct = !!disksize
-                    ? ((disksize - diskfree) / disksize) * 100
-                    : 0;
-                this.update({ usedSpacePercentage: usedPct });
+                await this.appelflapStatus();
 
                 const subscriptionsUpdated = await this.refreshSubscriptions();
                 await this.publishAll();
                 if (subscriptionsUpdated) {
                     CacheSubscribe.injectables().then(async (bundles) => {
                         if (bundles.bundles.length > 0) {
-                            // Unlock the cache and let Appelflap get on with it
-                            await CacheUtilities.unlock();
                             this.update({syncStatus: "syncOn"});
+                            // Tell Appelflap get on with it
+                            const result = await AppelflapUtilities.injectCache();
                         } else {
                             this.update({syncStatus: "syncNotRelevant"});
                         }
                     });
                 }
-                await this.appelflapStatus();
             },
 
             async onUnmounted() {
@@ -281,11 +262,32 @@
             },
 
             async appelflapStatus() {
-                this.update({ appelflapMeta: "Getting" });
+                // Get Peer info from Appelflap
+                const peerId = (await AppelflapUtilities.peerProperties()) || { friendly_ID: "unknown" };
+                const peers = await AppelflapUtilities.infoPeers();
+
+                // Get WiFi info from Appelflap
+                // Note the spelling mistake in `ipadress` and `ipadress_raw`
+                const { ssid, ipadress, ipadress_raw, strength } =
+                    (await AppelflapUtilities.infoWiFi())
+                    || { ssid: "", ipadress: "", ipadress_raw: 0, strength: 0 };
+
+                // Get the disk utilisation info from Appelflap
+                const { disksize, diskfree } = await AppelflapUtilities.infoStorage() || { disksize: 0, diskfree: 0 };
+                const usedPct = !!disksize
+                    ? ((disksize - diskfree) / disksize) * 100
+                    : 0;
 
                 // Get the Item Status Listing
-                await this.state.appDataStatus.BuildList();
-                this.update({statusListings: this.state.appDataStatus.itemListings});
+                const statusListings = await this.state.appDataStatus.ItemListings();
+
+                this.update({
+                    peerId: (await AppelflapUtilities.peerProperties()) || { friendly_ID: "unknown" },
+                    peers: await AppelflapUtilities.infoPeers(),
+                    ssid: ssid,
+                    usedSpacePercentage: usedPct,
+                    statusListings: statusListings,
+                });
             },
 
             async refreshSubscriptions() {
@@ -293,7 +295,7 @@
                 const subscriptions = await appDataStatus.SetSubscriptions();
                 if (JSON.stringify(subscriptions) === JSON.stringify({ types: { CACHE: { groups: {} } } })) {
                     // No subscriptions, several possible causes
-                    this.update({syncStatus: "syncSubscriptionError"});
+                    this.update({ syncStatus: "syncSubscriptionError" });
                     return false;
                 }
 

--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -4,7 +4,7 @@ import {
     TPublication,
     TSubscriptions,
 } from "../Types/CacheTypes";
-import { TBundles } from "../Types/BundleTypes";
+import { TBundleResults, TBundles } from "../Types/BundleTypes";
 
 /* eslint-disable prettier/prettier */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -210,6 +210,11 @@ export class AppelflapConnect {
         const { commandPath, method } =
             APPELFLAPCOMMANDS.doLaunchStorageManager;
         return await this.performCommand(commandPath, { method }, "text");
+    };
+
+    public doInjectCaches = async (): Promise<TBundleResults> => {
+        const { commandPath, method } = APPELFLAPCOMMANDS.doInjectCaches;
+        return await this.performCommand(commandPath, { method });
     };
     //#endregion
 

--- a/src/ts/Appelflap/AppelflapRouting.ts
+++ b/src/ts/Appelflap/AppelflapRouting.ts
@@ -32,6 +32,7 @@ export const AF_REBOOT_HARD = "hard-reboot";
 export const AF_REBOOT_SOFT = "soft-reboot";
 export const AF_LAUNCH_WIFIPICKER = "launch-wifipicker";
 export const AF_LAUNCH_STORAGEMANAGER = "launch-storagemanager";
+export const AF_INJECT_CACHES = "inject-caches";
 //#endregion
 
 //#region Appelflap Info Blocks
@@ -88,6 +89,10 @@ export const APPELFLAPCOMMANDS = {
     },
     doLaunchStorageManager: {
         commandPath: `${AF_ACTION_API}/${AF_LAUNCH_STORAGEMANAGER}`,
+        method: "POST",
+    },
+    doInjectCaches: {
+        commandPath: `${AF_ACTION_API}/${AF_INJECT_CACHES}`,
         method: "POST",
     },
     //#endregion

--- a/src/ts/Appelflap/AppelflapUtilities.ts
+++ b/src/ts/Appelflap/AppelflapUtilities.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { TBundleResults } from "../Types/BundleTypes";
 import {
     TInfoStorage,
     TInfoWiFi,
@@ -76,5 +77,17 @@ export class AppelflapUtilities {
         if (AppelflapConnect.getInstance()) {
             await AppelflapConnect.getInstance()!.doLaunchStorageManager();
         }
+    }
+
+    /**
+     * Instruct Appelflap to do all cache injections
+     * @note This will do cache injection without honouring the `cache.lock` (@see CacheUtilities.ts ).
+     * Therefore should only be called from a 'system' page, such as the Sync page.
+     */
+    static async injectCaches(): Promise<TBundleResults> {
+        if (AppelflapConnect.getInstance()) {
+            await AppelflapConnect.getInstance()!.doInjectCaches();
+        }
+        return { results: [] };
     }
 }

--- a/src/ts/Types/BundleTypes.ts
+++ b/src/ts/Types/BundleTypes.ts
@@ -14,3 +14,10 @@ export type TBundleMeta = {
 export type TBundles = {
     bundles: Array<TBundleMeta>;
 };
+
+export type TBundleResults = {
+    results: Array<{
+        bundle: TBundle;
+        success: boolean;
+    }>;
+};


### PR DESCRIPTION
# Description

Basic wiring of of the new Appelflap 'action' `inject-cache` all the way through to the sync page.

This does NOT handle the results coming back from `inject-cache`, which can be used to provide better feedback to the user, that will be a separate :pr:.

This does fix a bug in `AppDataStatus` where it wouldn't build the `itemListing` when needed (it relied on an external call to `BuildList` to rebuild it, this was undesirable).

This also does a first pass of cleaning up the `Sync` page code to better reflect where it is going in terms of functionality.  And a clean up of `AppDataStatus` making as many methods `private` as possible.