### PR TITLE
762: exam review bugfix

### DIFF
--- a/src/riot/Lesson/ExamReview.riot.html
+++ b/src/riot/Lesson/ExamReview.riot.html
@@ -64,7 +64,7 @@
             { TRANSLATIONS.retake() }
         </button>
 
-        <a onclick="{goToCourseOverview}">
+        <a class="back" onclick="{goToCourseOverview}">
             { TRANSLATIONS.backCourse() }
         </a>
     </div>
@@ -115,7 +115,7 @@
 
                 if (correctAnswers.length) {
                     return mappedQuestions.filter((it) => {
-                        return correctAnswers.some(a => a.id !== it.id)
+                        return !correctAnswers.find(a => a.id === it.id)
                     })
                 }
                 return mappedQuestions;

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -775,6 +775,14 @@ ExamReview {
             text-transform: uppercase;
         }
     }
+
+    .exam-summary {
+        display: block;
+
+        a.back {
+            display: block;
+        }
+    }
 }
 
 // Shared lesson styles

--- a/src/scss/_lesson.scss
+++ b/src/scss/_lesson.scss
@@ -646,6 +646,7 @@ ExamReview {
         align-items: center;
         text-align: center;
         height: 100%;
+        box-sizing: border-box;
         padding-bottom: 2em;
 
         h2,


### PR DESCRIPTION
closes #762 

Fixes the logic to determine incorrect answers to display for review (previously it was just displaying every question as opposed to just the incorrectly answered questions).
Also fixes the bug where you couldn't scroll down on the review screen when there were lots of questions to review.