### PR TITLE
More minor sync fixes

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -263,14 +263,13 @@
 
             async appelflapStatus() {
                 // Get Peer info from Appelflap
-                const peerId = (await AppelflapUtilities.peerProperties()) || { friendly_ID: "unknown" };
+                const peerId = (await AppelflapUtilities.peerProperties()) || { friendly_id: "unknown" };
                 const peers = await AppelflapUtilities.infoPeers();
 
                 // Get WiFi info from Appelflap
-                // Note the spelling mistake in `ipadress` and `ipadress_raw`
-                const { ssid, ipadress, ipadress_raw, strength } =
+                const { ssid, ipaddress, ipaddress_raw, strength } =
                     (await AppelflapUtilities.infoWiFi())
-                    || { ssid: "", ipadress: "", ipadress_raw: 0, strength: 0 };
+                    || { ssid: "", ipaddress: "", ipaddress_raw: 0, strength: 0 };
 
                 // Get the disk utilisation info from Appelflap
                 const { disksize, diskfree } = await AppelflapUtilities.infoStorage() || { disksize: 0, diskfree: 0 };

--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -142,7 +142,7 @@
                 statusListings: [],
                 appDataStatus: new AppDataStatus(),
                 ssid: "",
-                peerId: { friendly_ID: "unknown" },
+                peerId: { friendly_id: "unknown" },
                 peers: [],
                 // could be "outdated" or "current" - determined from the Manifest
                 contentStatus: "outdated",
@@ -202,7 +202,7 @@
             },
 
             get yourSyncAvatar() {
-                return this.mapAvatar(this.state.peerId.friendly_ID);
+                return this.mapAvatar(this.state.peerId.friendly_id);
             },
 
             get syncStatusText() {
@@ -211,7 +211,7 @@
 
             get mappedPeers() {
                 const peers = this.state.peers;
-                return peers.map((peer) => this.mapAvatar(peer.friendly_ID));
+                return peers.map((peer) => this.mapAvatar(peer.friendly_id));
             },
 
             get usedSpacePercentage() {

--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -235,17 +235,7 @@ export class AppelflapConnect {
 
     public infoPeers = async (): Promise<TPeers> => {
         const { commandPath, method } = APPELFLAPCOMMANDS.infoPeers;
-        // Note that the infoPeers command doesn't return the field names with the same case
-        // so some manipulation is required
-        const peers: TPeers = (
-            (await this.performCommand(commandPath, { method })) || []
-        ).map((peer: Record<string, any>) => {
-            return {
-                ID: peer.id,
-                friendly_ID: peer.friendly_ID,
-            } as TPeerProperties;
-        });
-        return peers;
+        return this.performCommand(commandPath, { method });
     };
 
     public infoStorage = async (): Promise<TInfoStorage> => {

--- a/src/ts/Types/InfoTypes.ts
+++ b/src/ts/Types/InfoTypes.ts
@@ -1,9 +1,9 @@
 /** A set of values that identify this user, as a peer for sharing */
 export type TPeerProperties = {
-    ID: number;
+    id: number;
     /** A 4 character representation of the @see ID, that has been derived from the @see palette */
-    friendly_ID: string;
-    /** This is the 'palette' of characters from which the @see friendly_ID has been formed */
+    friendly_id: string;
+    /** This is the 'palette' of characters from which the @see friendly_id has been formed */
     palette?: string;
 };
 

--- a/src/ts/Types/InfoTypes.ts
+++ b/src/ts/Types/InfoTypes.ts
@@ -14,14 +14,13 @@ export type TInfoWiFi = {
     ssid: string;
     /**
      * IP Address correctly formatted
-     * @remarks Note the spelling mistake in `ipadress`
      */
-    ipadress: string;
+    ipaddress: string;
     /**
      * IP Address as a simple number
-     * @remarks Note the spelling mistake in `ipadress_raw`
      */
-    ipadress_raw: number;
+    ipaddress_raw: number;
+    /** This is expressed as a number in the range 0-100 (inclusive) */
     strength: number;
 };
 

--- a/src/ts/tests/AppelflapConnect.test.ts
+++ b/src/ts/tests/AppelflapConnect.test.ts
@@ -493,8 +493,8 @@ test("Appelflap: peer ID", async (t: any) => {
 
     const testUri = `${AF_ENDPOINT}/${AF_PEER_PROPERTIES}`;
     const testResponse: TPeerProperties = {
-        ID: 3657874,
-        friendly_ID: "qZdP",
+        id: 3657874,
+        friendly_id: "qZdP",
         palette: "23456789abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ",
     };
     const successResponse = new Response(JSON.stringify(testResponse), {


### PR DESCRIPTION
Related: #795

as upstream has fixed a spelling error and made fieldname casing consistent with https://github.com/catalpainternational/appelflap/commit/2e76dc619c0a76b1ab0f1d2ac574c8234c80db71 and https://github.com/catalpainternational/appelflap/commit/bc81cf6c3260eda97275b6b097115a09fa74f6f5, this aims to incorporate those changes.