### PR TITLE
Workaround for whatever Appelflap thinks it's doin

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -171,6 +171,7 @@
                 syncCompleted: () => gettext("Content updated"), // There is no gaurantee that the user is 'all' up to date
                 syncNotRelevant: () => gettext("You have the latest version of available content"),
                 syncSubscriptionError: () => gettext("Subscribing to receive updated content failed"),
+                syncNoWiFiError: () => gettext("Subscribing for updated content needs WiFi"),
                 refresh: () => gettext("Refresh"),
                 avatar: () => gettext("Your sync avatar"),
                 peers: () => gettext("Recently seen peers"),
@@ -310,6 +311,13 @@
             },
 
             async refreshSubscriptions() {
+                // Note: this test is a workaround because Appelflap's `saveSubscriptions` method
+                // does not return when the device is not connected to WiFi
+                // Hopefully we can remove this later
+                if (!this.state.ssid) {
+                    this.update({ syncStatus: "syncNoWiFiError" });
+                    return false;
+                }
                 const subscriptions = await AppDataStatus.getInstance().SetSubscriptions();
                 if (JSON.stringify(subscriptions) === JSON.stringify({ types: { CACHE: { groups: {} } } })) {
                     // No subscriptions, several possible causes


### PR DESCRIPTION
# Description

When the user enters the Sync page, a key part of the Sync page's start up process is to refresh the subscriptions for everything in the manifest.

However ...

If the device is not connected to WiFi, for some reason the call to `GCLock.acquire()` in AppelFlap's `saveSubscription` method never returns.  I have no idea why 'acquiring' a garbage collection lock semaphore should have anything to do with WiFi, but it does, go figure.

So anyway, this is the workaround for the Sync page, until Appelflap can get its head together.