### PR TITLE
Syncing FE tweaks

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -113,7 +113,7 @@
                 // We will not know whether updates are available for them (totally depends on our peers sharing stuff)
                 // We will know whether everything that has been shared by others has been loaded in to our caches
                 // could be "syncOff", "syncOn" (in progress), "syncCompleted",
-                // "syncNotRelevant" (no more injectables), "syncSubscriptionError"
+                // "syncNotRelevant" (no more injectables), "syncSubscriptionError", "syncNoWiFiError"
                 syncStatus: "syncOff",
             },
 

--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -14,10 +14,9 @@
                 <div class="sync-status">
                     <div>
                         <h4>{ syncStatusText }</h4>
-                        <!-- TODO Get this date from the Manifest -->
-                        <p>{ new Date().toDateString() }</p>
+                        <p>{ TRANSLATIONS.lastUpdated() }: { lastUpdatedDate }</p>
                     </div>
-                    <div if="{state.syncStatus === 'updated'}" class="download-state complete">
+                    <div class="status-icon {state.syncStatus}">
                         <span class="icon"></span>
                     </div>
                 </div>
@@ -27,20 +26,16 @@
                 <h2>{ TRANSLATIONS.avatar() }</h2>
 
                 <p class="avatar {yourSyncAvatar.color}">
-                    {yourSyncAvatar.color}<br>
-                    {yourSyncAvatar.animal}<br>
-                    {yourSyncAvatar.plant}
+                    {yourSyncAvatar.id}<br>
                 </p>
             </div>
 
-            <div if="{mappedPeers}" class="group">
+            <div if="{mappedPeers.length}" class="group">
                 <h2>{ TRANSLATIONS.peers() }</h2>
 
                 <div class="peers">
                     <p each="{peer in mappedPeers}" class="avatar {peer.color}">
-                        {peer.color}<br>
-                        {peer.animal}<br>
-                        {peer.plant}
+                        {peer.id}
                     </p>
                 </div>
             </div>
@@ -91,40 +86,6 @@
                     <a onclick="{launchStorageManager}">{ TRANSLATIONS.launchStorageManager() }</a>
                 </p>
             </div>
-
-            <!-- TODO I think this list can be removed - it's no longer in the design -->
-            <ol class="sync-list">
-                <li
-                    each="{(statusListing, index) in state.statusListings}">
-                    <div class="sync-header">
-                        <h5><small>{statusListing.type}:</small> { statusListing.title }</h5>
-                    </div>
-                    <!-- <div class="sync-body"><small>version: {statusListing.version}</small></div> -->
-                    <!-- <div if="{statusListing.backendPath === statusListing.cacheKey}" class="sync-body">
-                        <span><small>Store Path/Cache Key:</small> { statusListing.backendPath }</span>
-                    </div> -->
-                    <!-- <div if="{statusListing.backendPath != statusListing.cacheKey}" class="sync-body">
-                        <span><small>Store Path:</small> { statusListing.backendPath }</span>
-                    </div> -->
-                    <!-- <div if="{statusListing.backendPath != statusListing.cacheKey}" class="sync-body">
-                        <span><small>Cache Key:</small> { statusListing.cacheKey }</span>
-                    </div> -->
-
-                    <div class="sync-body">
-                        <span><small>Publishable:</small> { statusListing.isPublishable }, </span>
-                    </div>
-
-                    <!-- <div class="sync-footer">
-                        <a class="action">
-                            <span class="arrow-blue"></span>
-                            <p>{ TRANSLATIONS.start() }</p>
-                        </a>
-                        <div>
-                            <p>{showTimeAgoFromNow(sync.timestamp)}</p>
-                        </div>
-                    </div> -->
-                </li>
-            </ol>
         </div>
     </div>
 
@@ -134,6 +95,7 @@
         import { CacheUtilities } from "ts/Appelflap/CacheUtilities";
         import { CacheSubscribe } from "ts/Appelflap/CacheSubscribe";
         import { hashString } from "js/utilities";
+        import { getRoute } from "ReduxImpl/Interface";
 
         import TopMenu from "riot/Components/TopMenu.riot.html";
 
@@ -163,12 +125,12 @@
                 start: () => gettext("Start lesson"),
                 syncTitle: () => gettext("Offline sync"),
                 status: () => gettext("Sync status"),
-                // It's not 'files' that are outdated, it's 'content'
+                lastUpdated: () => gettext("Last updated"),
                 contentOutdated: () => gettext("Some of your content is outdated"),
                 contentCurrent: () => gettext("You're all up to date"),
                 syncOff: () => gettext("Waiting to start syncing"),
                 syncOn: () => gettext("Getting updated content now"),
-                syncCompleted: () => gettext("Content updated"), // There is no gaurantee that the user is 'all' up to date
+                syncCompleted: () => gettext("Content updated"),
                 syncNotRelevant: () => gettext("You have the latest version of available content"),
                 syncSubscriptionError: () => gettext("Subscribing to receive updated content failed"),
                 refresh: () => gettext("Refresh"),
@@ -184,21 +146,22 @@
                 launchStorageManager: () => gettext("Free up space"),
             },
 
+            get manifest() {
+                return getRoute().page.manifest;
+            },
+
+            get lastUpdatedDate() {
+                return new Date(this.manifest.version / 1000).toDateString();
+            },
+
             mapAvatar(id) {
-                // TODO we'll probably need to translate these (but the colors for classes need to remain in English)
                 const colors = ['pink','red','orange','yellow','teal','blue','purple'];
-                const animals = ['bird','monkey','fish','dog','seal','shrimp','whale','dolphin',
-                    'starfish','urchin','shark','porpoise','sloth','python','frog'];
-                const plants = ['tree','grass','weed','sedge','shrub','rush','fern','coral',
-                    'acorn','moss','nettle','flower'];
 
                 const idHash = hashString("" + id);
 
                 return {
                     id,
                     color: colors[idHash % colors.length],
-                    animal: animals[idHash % animals.length],
-                    plant: plants[idHash % plants.length],
                 }
             },
 
@@ -231,7 +194,6 @@
             get connection() {
                 return {
                     type: this.state.ssid ? "wifi" : "",
-                    // TODO I'm not sure if we can get the network name?
                     networkName: this.state.ssid || "",
                 }
             },
@@ -300,7 +262,7 @@
                     name: "usedSpacePercentage",
                     source: AppelflapUtilities.infoStorage,
                     default: { disksize: 0, diskfree: 0 },
-                    getValue: (value) => { 
+                    getValue: (value) => {
                         const { disksize, diskfree } = value;
                         return !!disksize
                             ? ((disksize - diskfree) / disksize) * 100

--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -241,9 +241,6 @@
             },
 
             appelflapStatus() {
-                // Get the Item Status Listings
-                // this.updateStatusData("statusListings", AppDataStatus.getInstance().ItemListings, [] );
-
                 // Get Peer info from Appelflap
                 this.updateStatusData({ name: "peerId", source: AppelflapUtilities.peerProperties, default: peerPropDefault });
                 this.updateStatusData({ name: "peers", source: AppelflapUtilities.infoPeers, default: [] });

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -167,8 +167,7 @@ Sync {
 
         &.syncOff,
         &.syncOn {
-            // Waiting to start syncing
-            // Getting updated content now
+            // Waiting to start syncing or Getting updated content now
             &::after {
                 content: '';
                 border: 2px solid $gray-8;
@@ -186,8 +185,7 @@ Sync {
 
         &.syncCompleted,
         &.syncNotRelevant {
-            // Content updated
-            // You have the latest version of available content
+            // Content updated or You have the latest version of available content
             @extend %status-complete;
             width: 32px;
             height: 32px;
@@ -198,8 +196,9 @@ Sync {
             }
         }
 
-        &.syncSubscriptionError {
-            // Subscribing to receive updated content failed
+        &.syncSubscriptionError,
+        &.syncNoWiFiError {
+            // Subscribing to receive updated content failed or not connected to wifi
             @include unmaskable-icons-shared("~img/incorrect_cross.svg", contain);
         }
     }

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -159,26 +159,16 @@ Sync {
         background-color: $white;
     }
 
-    .download-state {
-        background-color: $app-accent-color;
+    .status-icon {
         width: 30px;
         height: 30px;
         border-radius: 100%;
         position: relative;
 
-        .download {
-            background-color: $white;
-            margin-left: 2px;
-            margin-top: 1px;
-        }
-
-        &.loading {
-            background-color: unset;
-
-            .download {
-                background-color: $app-accent-color;
-            }
-
+        &.syncOff,
+        &.syncOn {
+            // Waiting to start syncing
+            // Getting updated content now
             &::after {
                 content: '';
                 border: 2px solid $gray-8;
@@ -194,7 +184,10 @@ Sync {
             }
         }
 
-        &.complete {
+        &.syncCompleted,
+        &.syncNotRelevant {
+            // Content updated
+            // You have the latest version of available content
             @extend %status-complete;
             width: 32px;
             height: 32px;
@@ -203,6 +196,11 @@ Sync {
                 height: 12px;
                 width: 15px;
             }
+        }
+
+        &.syncSubscriptionError {
+            // Subscribing to receive updated content failed
+            @include unmaskable-icons-shared("~img/incorrect_cross.svg", contain);
         }
     }
 


### PR DESCRIPTION
Towards #604 

Some small tweaks:
- remove the list of 'statusListings'
- show the last updated date in the sync status (defined by the manifest version)
- update to the status icon according to `syncStatus` - loading icon if loading, tick if done, cross if error
- strip back the peer avatars for now - just display `friendly_id` and map to colours (some discussion about that [here](https://github.com/catalpainternational/canoe/issues/604) but awaiting further direction)
