### PR TITLE
Disable double tap zoom

### DIFF
--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -82,6 +82,12 @@ button {
     font-weight: 400;
 }
 
+button,
+a {
+    // disables the double-tap-to-zoom behaviour
+    touch-action: manipulation;
+}
+
 label {
     font-family: $app-typography;
     font-size: 1em;

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -82,12 +82,6 @@ button {
     font-weight: 400;
 }
 
-button,
-a {
-    // disables the double-tap-to-zoom behaviour
-    touch-action: manipulation;
-}
-
 label {
     font-family: $app-typography;
     font-size: 1em;

--- a/src/scss/canoe.scss
+++ b/src/scss/canoe.scss
@@ -39,6 +39,8 @@
 * {
     margin: 0;
     padding: 0;
+    // disables the double-tap-to-zoom behaviour
+    touch-action: manipulation;
 }
 
 div.content-wrapper {


### PR DESCRIPTION
Disables the double tap to zoom behaviour, while still allowing pinch to zoom, globally

https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action