### PR TITLE
Subscription API changes

### DIFF
--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -308,13 +308,8 @@
             },
 
             async refreshSubscriptions() {
-                // Note: this first test is a workaround because Appelflap's `saveSubscriptions` method
-                // does not return when the device is not connected to WiFi.
-                // This test examines whether the ssid is set or not.
-                // Hopefully we can remove this later
-                if (!this.setSyncStatus()) {
-                    return false;
-                }
+                this.state.taggedSubs = await AppDataStatus.getInstance().GetSubscriptions();
+
                 this.state.taggedSubs = await AppDataStatus.getInstance().SetSubscriptions();
                 if (!this.setSyncStatus()) {
                     return false;

--- a/src/riot/Screens/Sync.riot.html
+++ b/src/riot/Screens/Sync.riot.html
@@ -94,13 +94,14 @@
         import { AppelflapUtilities } from "ts/Appelflap/AppelflapUtilities";
         import { CacheUtilities } from "ts/Appelflap/CacheUtilities";
         import { CacheSubscribe } from "ts/Appelflap/CacheSubscribe";
+        import { AF_EMPTY_TAGGED_SUBSCRIPTIONS } from "ts/Constants";
         import { hashString } from "js/utilities";
         import { getRoute } from "ReduxImpl/Interface";
 
         import TopMenu from "riot/Components/TopMenu.riot.html";
 
         const peerPropDefault = { friendly_id: "unknown" };
-        const subscriptionsDefault = { types: { CACHE: { groups: {} } } };
+        const taggedSubsDefault = AF_EMPTY_TAGGED_SUBSCRIPTIONS;
 
         export default {
             state: {
@@ -108,7 +109,7 @@
                 ssid: "",
                 peerId: peerPropDefault,
                 peers: [],
-                subscriptions: subscriptionsDefault,
+                taggedSubs: taggedSubsDefault,
                 // could be "outdated" or "current" - determined from the Manifest
                 contentStatus: "outdated",
                 // We will know if 'content' (cache bandles) are outdated from what the Manifest tells us
@@ -243,7 +244,7 @@
                     this.update({ syncStatus: "syncNoPeersError" });
                     return false;
                 }
-                if (JSON.stringify(this.state.subscriptions) === JSON.stringify(subscriptionsDefault) && !forceDesiredState) {
+                if (JSON.stringify(this.state.taggedSubs) === JSON.stringify(taggedSubsDefault) && !forceDesiredState) {
                     // No subscriptions, several possible causes
                     this.update({ syncStatus: "syncSubscriptionError" });
                     return false;
@@ -314,7 +315,7 @@
                 if (!this.setSyncStatus()) {
                     return false;
                 }
-                this.state.subscriptions = await AppDataStatus.getInstance().SetSubscriptions();
+                this.state.taggedSubs = await AppDataStatus.getInstance().SetSubscriptions();
                 if (!this.setSyncStatus()) {
                     return false;
                 }

--- a/src/ts/Appelflap/AppelflapConnect.ts
+++ b/src/ts/Appelflap/AppelflapConnect.ts
@@ -3,13 +3,14 @@ import {
     TCertificate,
     TPublication,
     TSubscriptions,
+    TTaggedSubscriptions,
 } from "../Types/CacheTypes";
 import { TBundleResults, TBundles } from "../Types/BundleTypes";
 
 /* eslint-disable prettier/prettier */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: For when the unit tests cannot find the declaration file
-import { AF_CERTCHAIN_LENGTH_HEADER, AF_LOCALHOSTURI, APPELFLAPCOMMANDS } from "./AppelflapRouting";
+import { AF_CERTCHAIN_LENGTH_HEADER, AF_ETAG, AF_LOCALHOSTURI, APPELFLAPCOMMANDS } from "./AppelflapRouting";
 // The above import statement MUST all appear on the one line for the @ts-ignore to work
 /* eslint-enable prettier/prettier */
 
@@ -109,7 +110,7 @@ export class AppelflapConnect {
     private performCommand = async (
         commandPath: string,
         commandInit?: RequestInit,
-        returnType: "json" | "text" | "pem" = "json"
+        returnType: "json" | "text" | "response" = "json"
     ): Promise<any> => {
         await this.getEndpointProperties();
         if (!this.#endpointProperties) {
@@ -143,19 +144,8 @@ export class AppelflapConnect {
             case "text":
                 const testResult = await response.text();
                 return testResult || response.statusText;
-            case "pem":
-                // A `application/x-pem-file` is actually a sub-type of `text`
-                // But we need to include a little extra info from the repsonse header.
-                // So we'll actually return it as an object (i.e. json)
-                const encodedCertificate = await response.text();
-                const isCertSigned =
-                    response.headers.get(AF_CERTCHAIN_LENGTH_HEADER) === "3";
-                const cert = {
-                    cert: encodedCertificate,
-                    isCertSigned: isCertSigned,
-                } as TCertificate;
-
-                return cert;
+            case "response":
+                return response;
         }
         /* eslint-enable no-case-declarations */
     };
@@ -296,16 +286,29 @@ export class AppelflapConnect {
     //#endregion
 
     //#region Subscriptions
-    public getSubscriptions = async (): Promise<TSubscriptions> => {
+    public getSubscriptions = async (): Promise<TTaggedSubscriptions> => {
         const { commandPath } = APPELFLAPCOMMANDS.getSubscriptions;
 
-        const subscriptions = await this.performCommand(commandPath);
-        return subscriptions as Promise<TSubscriptions>;
+        const subResponse = (await this.performCommand(
+            commandPath,
+            undefined,
+            "response"
+        )) as Response;
+
+        const getSubscriptions: TTaggedSubscriptions = {
+            eTag: subResponse.headers.get(AF_ETAG) || "",
+            subscriptions: (await subResponse.json()) as TSubscriptions,
+        };
+
+        logger.info(
+            `Got current subscriptions with the ETag ${getSubscriptions.eTag}`
+        );
+        return getSubscriptions;
     };
 
     public setSubscriptions = async (
-        subscriptions: TSubscriptions
-    ): Promise<TSubscriptions> => {
+        taggedSubs: TTaggedSubscriptions
+    ): Promise<TTaggedSubscriptions> => {
         logger.info(`Setting subscriptions for desired items`);
 
         const { commandPath, method } = APPELFLAPCOMMANDS.setSubscriptions;
@@ -314,14 +317,21 @@ export class AppelflapConnect {
             method: method,
             headers: {
                 "content-type": "application/json",
+                "If-Match": taggedSubs.eTag,
             },
-            body: JSON.stringify(subscriptions),
+            body: JSON.stringify(taggedSubs.subscriptions),
         };
 
-        const setSubscriptions: TSubscriptions = await this.performCommand(
+        const subResponse = (await this.performCommand(
             requestPath,
-            commandInit
-        );
+            commandInit,
+            "response"
+        )) as Response;
+
+        const setSubscriptions: TTaggedSubscriptions = {
+            eTag: subResponse.headers.get(AF_ETAG) || "",
+            subscriptions: (await subResponse.json()) as TSubscriptions,
+        };
 
         logger.info(`Successfully set subscriptions for desired items`);
         return setSubscriptions;
@@ -346,15 +356,26 @@ export class AppelflapConnect {
     public getCertificate = async (): Promise<TCertificate> => {
         const { commandPath } = APPELFLAPCOMMANDS.getCertificate;
 
-        const certificate = (await this.performCommand(
+        const certResponse = (await this.performCommand(
             commandPath,
             undefined,
-            "pem"
-        )) as TCertificate;
+            "response"
+        )) as Response;
 
-        const certSigned = certificate.isCertSigned ? "signed" : "unsigned";
+        // A `application/x-pem-file` is actually a sub-type of `text`
+        // But we need to include a little extra info from the response header.
+        // So we'll actually return it as an object (i.e. json)
+        const encodedCertificate = await certResponse.text();
+        const isCertSigned =
+            certResponse.headers.get(AF_CERTCHAIN_LENGTH_HEADER) === "3";
+        const cert = {
+            cert: encodedCertificate,
+            isCertSigned: isCertSigned,
+        } as TCertificate;
+
+        const certSigned = cert.isCertSigned ? "signed" : "unsigned";
         logger.info(`Got ${certSigned} certificate`);
-        return certificate;
+        return cert;
     };
 
     public saveCertificate = async (

--- a/src/ts/Appelflap/AppelflapRouting.ts
+++ b/src/ts/Appelflap/AppelflapRouting.ts
@@ -42,6 +42,7 @@ export const AF_STORAGE_INFO = "storage-info";
 //#endregion
 
 export const AF_CERTCHAIN_LENGTH_HEADER = "X-Appelflap-Chain-Length";
+export const AF_ETAG = "ETag";
 
 /** These are all of the commands provided by Appelflap across its API surface that we wish to expose */
 export const APPELFLAPCOMMANDS = {
@@ -119,12 +120,6 @@ export const APPELFLAPCOMMANDS = {
         commandPath: `${AF_CACHE_API}/${AF_PUBLICATIONS}`,
         method: "PUT",
     },
-    /** @deprecated Do not use, this is performed by Appelflap garbage collection now */
-    // deletePublication: {
-    //     commandPath: `${AF_CACHE_API}/${AF_PUBLICATIONS}`,
-    //     method: "DELETE",
-    // },
-    //#endregion
     //#region Subscriptions
     getSubscriptions: {
         commandPath: `${AF_CACHE_API}/${AF_SUBSCRIPTIONS}`,

--- a/src/ts/Appelflap/CacheSubscribe.ts
+++ b/src/ts/Appelflap/CacheSubscribe.ts
@@ -1,29 +1,30 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { AF_EMPTY_TAGGED_SUBSCRIPTIONS } from "../Constants";
 import { TBundles } from "../Types/BundleTypes";
-import { TSubscriptions } from "../Types/CacheTypes";
+import { TTaggedSubscriptions } from "../Types/CacheTypes";
 import { AppelflapConnect } from "./AppelflapConnect";
 
 export class CacheSubscribe {
-    static async getSubscriptions(): Promise<TSubscriptions> {
+    static async getSubscriptions(): Promise<TTaggedSubscriptions> {
         if (AppelflapConnect.getInstance()) {
-            const subscriptions =
+            const taggedSubs =
                 await AppelflapConnect.getInstance()!.getSubscriptions();
-            if (subscriptions.types.CACHE) {
-                return subscriptions;
+            if (taggedSubs.subscriptions.types.CACHE) {
+                return taggedSubs;
             }
         }
-        return { types: { CACHE: { groups: {} } } };
+        return AF_EMPTY_TAGGED_SUBSCRIPTIONS;
     }
 
     static async setSubscriptions(
-        subscriptions: TSubscriptions
-    ): Promise<TSubscriptions> {
+        taggedSubs: TTaggedSubscriptions
+    ): Promise<TTaggedSubscriptions> {
         if (AppelflapConnect.getInstance()) {
             return await AppelflapConnect.getInstance()!.setSubscriptions(
-                subscriptions
+                taggedSubs
             );
         }
-        return { types: { CACHE: { groups: {} } } };
+        return AF_EMPTY_TAGGED_SUBSCRIPTIONS;
     }
 
     /**

--- a/src/ts/Constants.ts
+++ b/src/ts/Constants.ts
@@ -1,6 +1,13 @@
 /* A place to define various magic strings etc. that do not belong in urls.js */
 
+import { TTaggedSubscriptions } from "./Types/CacheTypes";
+
 export const EMPTY_SLATE_BOOT_KEY = "empty_slate_boot";
+
+export const AF_EMPTY_TAGGED_SUBSCRIPTIONS: TTaggedSubscriptions = {
+    eTag: "",
+    subscriptions: { types: { CACHE: { groups: {} } } },
+};
 
 /**
  * This action is 'not relevant' because we're:

--- a/src/ts/Implementations/ItemActions.ts
+++ b/src/ts/Implementations/ItemActions.ts
@@ -100,6 +100,7 @@ export async function setSubscriptions(
     }
 
     const taggedSubs = AF_EMPTY_TAGGED_SUBSCRIPTIONS;
+    taggedSubs.eTag = eTag;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     taggedSubs.subscriptions.types.CACHE!.groups[self.origin] = { names: {} };
 

--- a/src/ts/Types/CacheTypes.ts
+++ b/src/ts/Types/CacheTypes.ts
@@ -37,6 +37,11 @@ export type TSubscriptions = {
     };
 };
 
+export type TTaggedSubscriptions = {
+    eTag: string;
+    subscriptions: TSubscriptions;
+};
+
 export type TCertificate = {
     /** The body of the pem certificate file, as a text string */
     cert: string;


### PR DESCRIPTION
# Description

This implements the changes in the `subscription` API that have now become mandatory.  In particular the use of an `ETag`.

This change propagates through the stack of Appelflap handling code, so lots of very similar code changes.