### PR TITLE
813: fix modal rollup stacking

### DIFF
--- a/src/riot/WagtailPages/CoursePage.riot.html
+++ b/src/riot/WagtailPages/CoursePage.riot.html
@@ -124,7 +124,7 @@
         </div>
     </div>
 
-    <PopupModal if="{state.showDownloadModal}" togalModal="{toggleDownloadModal}">
+    <PopupModal if="{state.showDownloadModal}">
         <span class="download-course"></span>
         <h3>{ TRANSLATIONS.download_course() }</h3>
         <!-- <button class="btn-primary" onclick="{downloadAllLessons}">{ TRANSLATIONS.download_all() }</button> -->

--- a/src/scss/_course.scss
+++ b/src/scss/_course.scss
@@ -65,7 +65,7 @@ Resources {
     }
 
     .modal {
-        height: 90vh;
+        height: 75vh;
     }
 
     .modal .btn-primary {

--- a/src/scss/_modal.scss
+++ b/src/scss/_modal.scss
@@ -15,7 +15,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    z-index: 2;
+    z-index: 3;
 
     & > div {
         flex-direction: row;


### PR DESCRIPTION
Fixes the issues described in #813 by correctly stacking the modal above the bottom menu. Also decreases the height of the rollup to better fit on iOS

<img src="https://user-images.githubusercontent.com/12974326/125217720-b0c4e480-e304-11eb-95c3-bce9dbf13023.jpeg" width="250">
