### PR TITLE
refine resource listing cards & offline button

### DIFF
--- a/src/riot/Components/LessonDownload.riot.html
+++ b/src/riot/Components/LessonDownload.riot.html
@@ -1,5 +1,5 @@
-<LessonDownload class="{ props.iconOnly ? '' : 'download-block' }">
-    <template if="{!props.iconOnly}">
+<LessonDownload class="{ props.resourceDownload ? '' : 'download-block' }">
+    <template if="{!props.resourceDownload}">
         <p class="lesson-number">{props.itemIndex + 1}</p>
         <p class="title">{props.contentItem.title}</p>
         <div class="download-state" onclick="{toggleCached}">
@@ -12,12 +12,12 @@
         </div>
     </template>
 
-    <template if="{props.iconOnly}">
+    <template if="{props.resourceDownload}">
         <div onclick="{ toggleCached }" class="download-button">
-            <template if="{ state.cached }">
-                <span class="download"></span>
-                <p>{ TRANSLATIONS.downloaded() }</p>
-            </template>
+            <div if="{ state.cached }" class="resource-downloaded">
+                <span class="checkmark teal"></span>
+                <p>{ TRANSLATIONS.available() }</p>
+            </div>
             <template if="{ !state.cached }">
                 <span class="download gray"></span>
                 <p>{ TRANSLATIONS.make() }</p>
@@ -35,7 +35,7 @@
             TRANSLATIONS: {
                 issue: () => gettext("There was a problem downloading the content"),
                 make: () => gettext("Make offline"),
-                downloaded: () => gettext("Downloaded"),
+                available: () => gettext("Available offline"),
             },
 
             onMounted(props, state) {

--- a/src/riot/Screens/Resources.riot.html
+++ b/src/riot/Screens/Resources.riot.html
@@ -18,18 +18,17 @@
             <div
                 each="{resource in page.resources}"
                 if="{isResourceVisible(resource)}"
-                class="resource-card"
+                class="resource-card {resource.cardImage ? 'has-image' : ''}"
             >
+                <div class="image-wrapper" if="{resource.cardImage}">
+                    <img src="{getCardImage(resource.loc_hash, resource.cardImage)}">
+                </div>
                 <a href="#{resource.loc_hash}" class="resource-content">
-                    <span each="{ type in resource.cardTypes }">
-                        <p>{ type }</p>
-                        <span if="{ resource.cardTypes.length > 1 }">,</span>
-                    </span>
                     <h5>{ resource.title }</h5>
-                    <h6>{ resource.description }</h6>
+                    <p>{ resource.description }</p>
                 </a>
                 <LessonDownload
-                    iconOnly="{true}"
+                    resourceDownload="{true}"
                     contentItem="{resource}"
                 ></LessonDownload>
             </div>
@@ -46,6 +45,7 @@
         import LessonDownload from "RiotTags/Components/LessonDownload.riot.html";
 
         import { getRoute } from "ReduxImpl/Interface";
+        import { getCardImageUrl } from "js/utilities";
 
         import {
             doPageTagsMatchSelections,
@@ -115,6 +115,10 @@
 
                 const show = isQueryMatch && isTagMatch;
                 return show;
+            },
+
+            getCardImage(link, cardImage) {
+                return getCardImageUrl(link, cardImage);
             },
         };
     </script>

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -57,12 +57,7 @@ Card {
         }
 
         .clamp-lines {
-            line-height: 1.2em;
-            height: calc(3 * 1.2em);
-            overflow: hidden;
-            display: -webkit-box;
-            -webkit-line-clamp: 3;
-            -webkit-box-orient: vertical;
+            @extend %clamp-3-lines;
         }
     }
 
@@ -136,8 +131,7 @@ AllTopicsList .card {
             min-height: 80px;
 
             .clamp-lines {
-                height: calc(2 * 1.2em);
-                -webkit-line-clamp: 2;
+                @extend %clamp-2-lines;
             }
         }
     }

--- a/src/scss/_course.scss
+++ b/src/scss/_course.scss
@@ -39,12 +39,7 @@ CoursePage {
             }
 
             .clamp-3-lines {
-                line-height: 1.2em;
-                height: calc(3 * 1.2em);
-                overflow: hidden;
-                display: -webkit-box;
-                -webkit-line-clamp: 3;
-                -webkit-box-orient: vertical;
+                @extend %clamp-3-lines;
             }
         }
     }
@@ -160,12 +155,37 @@ Resources {
         justify-content: center;
         gap: 3px;
         height: 100%;
+        position: relative;
+        padding-right: 18px;
 
         p {
             font-size: 0.5em;
             text-align: center;
             text-transform: uppercase;
             color: $gray-4;
+        }
+
+        .resource-downloaded {
+            position: absolute;
+            top: 0;
+            right: 0;
+            background-color: $gray-8;
+            border-radius: 0 0 0 8px;
+            min-width: 100px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            padding: 0 5px;
+
+            .checkmark {
+                width: 11px;
+                height: 11px;
+            }
+
+            p {
+                color: $gray-1;
+            }
         }
     }
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -34,3 +34,22 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+%clamp-lines {
+    overflow: hidden;
+    line-height: 1.2em;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+}
+
+%clamp-2-lines {
+    @extend %clamp-lines;
+    height: calc(2 * 1.2em);
+    -webkit-line-clamp: 2;
+}
+
+%clamp-3-lines {
+    @extend %clamp-lines;
+    height: calc(3 * 1.2em);
+    -webkit-line-clamp: 3;
+}

--- a/src/scss/_resources.scss
+++ b/src/scss/_resources.scss
@@ -20,44 +20,44 @@ Resources {
         .resource-card {
             background-color: $gray-10;
             margin-bottom: 3px;
-            padding: 12px 18px;
             height: 110px;
             display: grid;
-            grid-template-columns: calc(100% - 40px) 40px;
+            grid-template-columns: 1fr 50px;
+            gap: 1em;
             width: 100%;
             box-sizing: border-box;
+
+            &.has-image {
+                grid-template-columns: 110px 1fr 50px;
+
+                .resource-content {
+                    padding-left: 0;
+                }
+
+                .image-wrapper > img {
+                    object-fit: cover;
+                    width: 100%;
+                    height: 100%;
+                }
+            }
 
             .resource-content {
                 display: block;
                 box-sizing: border-box;
+                padding: 16px 0 16px 18px;
 
                 h5 {
+                    @extend %clamp-2-lines;
+                    height: unset;
+                    max-height: calc(2 * 1.2em);
                     color: $gray-1;
                     font-size: 1em;
                     margin: 5px auto;
                 }
 
-                h6 {
-                    color: $gray-3;
-                    font-size: 14px;
-                    @extend %truncate-with-ellipsis;
-                }
-
-                p,
-                span {
-                    color: $gray-4;
-                    text-transform: uppercase;
-                    font-size: 0.75em;
-                    display: inline-block;
-                    letter-spacing: 0.6px;
-
-                    span {
-                        margin-right: 3px;
-                    }
-                }
-
-                span:last-of-type span {
-                    display: none;
+                p {
+                    @extend %clamp-2-lines;
+                    font-size: 0.85em;
                 }
             }
         }


### PR DESCRIPTION
Closes #738 

Refreshes the styles for resource listings according to the design [here](https://projects.invisionapp.com/d/main/#/console/20251865/429853508/inspect).

Updates the downloaded state, and adds in an image if one has been added.

<img src="https://user-images.githubusercontent.com/12974326/125239962-c4844100-e32c-11eb-9d37-fafe4211e5dc.png" width="300">
