### PR TITLE
813 fix modal rollup dismount

### DIFF
--- a/src/riot/Components/PopupModal.riot.html
+++ b/src/riot/Components/PopupModal.riot.html
@@ -14,6 +14,7 @@
             },
 
             onUnmounted(props, state) {
+                document.body.classList.remove('modal-open');
                 const { toggleModal } = props;
                 if (!toggleModal) {
                     return;


### PR DESCRIPTION
Closes #813 (follow up to https://github.com/catalpainternational/canoe/pull/816)

explicitly removes the body class which prevents scrolling when the popupmodal is unmounted (like when the user hits the back button).